### PR TITLE
COR-FIX adandoned cart url issues

### DIFF
--- a/Controller/AbandonedCart/LoadCart.php
+++ b/Controller/AbandonedCart/LoadCart.php
@@ -157,7 +157,7 @@ class LoadCart implements ActionInterface
         /** @phpstan-ignore-next-line */
         if ($abandonedQuote->getCustomerId()) {
             $this->yotpoSmsBumpSession->start();
-            $this->yotpoSmsBumpSession->setData('yotpoToken', $abandonedCartQuoteId);
+            $this->yotpoSmsBumpSession->setData('yotpoQuoteToken', $abandonedCartQuoteId);
             return $this->resultRedirectFactory->create()->setPath('customer/account/login');
         }
 

--- a/Controller/AbandonedCart/LoadCart.php
+++ b/Controller/AbandonedCart/LoadCart.php
@@ -17,7 +17,6 @@ use Magento\Framework\App\Response\RedirectInterface;
 use Magento\Framework\Controller\Result\RedirectFactory;
 use Magento\Quote\Model\QuoteRepository;
 use Magento\Checkout\Model\Type\Onepage;
-use Magento\Framework\View\Result\PageFactory;
 use Magento\Checkout\Model\DefaultConfigProvider;
 use Yotpo\SmsBump\Model\Session as YotpoSmsBumpSession;
 use Yotpo\SmsBump\Model\AbandonedCart\Data as AbandonedCartData;
@@ -48,11 +47,6 @@ class LoadCart implements ActionInterface
      * @var RedirectFactory
      */
     protected $resultRedirectFactory;
-
-    /**
-     * @var PageFactory
-     */
-    protected $resultPageFactory;
 
     /**
      * @var Onepage
@@ -97,7 +91,6 @@ class LoadCart implements ActionInterface
      * @param QuoteRepository $quoteRepository
      * @param RedirectFactory $resultRedirectFactory
      * @param Onepage $onepage
-     * @param PageFactory $resultPageFactory
      * @param CustomerSession $customerSession
      * @param DefaultConfigProvider $defaultConfigProvider
      * @param YotpoSmsBumpSession $yotpoSmsBumpSession
@@ -111,7 +104,6 @@ class LoadCart implements ActionInterface
         QuoteRepository $quoteRepository,
         RedirectFactory $resultRedirectFactory,
         Onepage $onepage,
-        PageFactory $resultPageFactory,
         CustomerSession $customerSession,
         DefaultConfigProvider $defaultConfigProvider,
         YotpoSmsBumpSession $yotpoSmsBumpSession,
@@ -124,7 +116,6 @@ class LoadCart implements ActionInterface
         $this->quoteRepository = $quoteRepository;
         $this->resultRedirectFactory = $resultRedirectFactory;
         $this->onepage = $onepage;
-        $this->resultPageFactory = $resultPageFactory;
         $this->customerSession = $customerSession;
         $this->defaultConfigProvider = $defaultConfigProvider;
         $this->yotpoSmsBumpSession = $yotpoSmsBumpSession;
@@ -175,7 +166,8 @@ class LoadCart implements ActionInterface
             return $this->resultRedirectFactory->create()->setPath('/');
         }
 
-        $resultPage = $this->resultPageFactory->create();
+        $this->checkoutSession->setQuoteId($abandonedCartQuoteId);
+        $resultPage = $this->resultRedirectFactory->create()->setPath('checkout/cart');
         $resultPage->setHeader('Yotpo-Abandoned-Cart', 'true');
         return $resultPage;
     }

--- a/Model/AbandonedCart/Data.php
+++ b/Model/AbandonedCart/Data.php
@@ -75,9 +75,9 @@ class Data extends AbstractJobs
     /**
      * @return mixed|null
      */
-    public function getYotpoToken()
+    public function getYotpoQuoteToken()
     {
-        return $this->yotpoSmsBumpSession->getData('yotpoToken');
+        return $this->yotpoSmsBumpSession->getData('yotpoQuoteToken');
     }
 
     /**
@@ -104,10 +104,10 @@ class Data extends AbstractJobs
     }
 
     /**
-     * @param string $yotpoToken
+     * @param string $quoteToken
      * @return string
      */
-    public function getQuoteId($yotpoToken)
+    public function getQuoteId($quoteToken)
     {
         $connection = $this->resourceConnection->getConnection();
         $query = $connection->select()->from(
@@ -115,7 +115,7 @@ class Data extends AbstractJobs
             'e.quote_id'
         )->where(
             'quote_token = ?',
-            $yotpoToken
+            $quoteToken
         );
         return $connection->fetchOne($query);
     }

--- a/Plugin/Checkout/DefaultConfigProviderPlugin.php
+++ b/Plugin/Checkout/DefaultConfigProviderPlugin.php
@@ -68,7 +68,7 @@ class DefaultConfigProviderPlugin
      */
     public function afterGetConfig($subject, $result)
     {
-        $yotpoAbandonedQuoteId = $this->yotpoSmsBumpSession->getData('yotpoToken');
+        $yotpoAbandonedQuoteId = $this->yotpoSmsBumpSession->getData('yotpoQuoteToken');
         $quote = $this->checkoutSession->getQuote();
         $email = $quote->getShippingAddress()->getEmail();
         if (!$email) {

--- a/Plugin/Customer/Account/LoginPost.php
+++ b/Plugin/Customer/Account/LoginPost.php
@@ -69,9 +69,9 @@ class LoginPost
         }
 
         $customRedirectionUrl = $this->url->getUrl('checkout', ['_fragment' => 'payment']);
-        $yotpoToken = $this->abandonedCartData->getYotpoToken();
-        if ($yotpoToken) {
-            $isValidQuote = $this->abandonedCartData->setQuoteData($yotpoToken);
+        $yotpoQuoteToken = $this->abandonedCartData->getYotpoQuoteToken();
+        if ($yotpoQuoteToken) {
+            $this->abandonedCartData->setQuoteData($yotpoQuoteToken);
             $resultRedirect = $this->resultRedirectFactory->create();
             $resultRedirect->setUrl($customRedirectionUrl);
             return $resultRedirect;


### PR DESCRIPTION
## Background
The module [registers](https://github.com/YotpoLtd/magento2-module-messaging/blob/master/etc/frontend/routes.xml#L4) a custom route under the `yotposmsbump` namespace.

The `LoadCart implements ActionInterface` reacts to `/yotposmsbump/abandonedcart/loadcart`.
The URL should include the `yotpoQuoteToken` as a URL variable in the following format:
`/yotposmsbump/abandonedcart/loadcart/yotpoQuoteToken/{QUOTE_TOKEN}`

## Issues
### Issue 1
The `abandoned_checkout_url` that is being sent to Yotpo is `/yotposmsbump/abandonedcart/loadcart/yotpoQuoteToken/{QUOTE_TOKEN}`, but it leads to a blank page instead of to the store's checkout page.

The `LoadCart#execute` action validates the `QuoteToken` validity, and then redirects to the store front, based on the shopper status.

- For Registered Shoppers, the `abandonedCartQuoteId` is set on the SMSSession as `yotpoToken`. Which is then being used on `LoginPost#afterExecute`.
- For Guest Shoppers, the URL leads to a blank page. The current logic is different than the one that is used on `LoginPost` and doesn't redirect correctly.

### Issue 2 - not handled on this PR
For a logged-in customer, if the quote is invalid the page still gets redirected to the payment (LoginPost#afterExecute).

### Issue 3 - not handled on this PR
For Registered Shoppers, the user is logged out even if the `QuoteToken` belongs to the shopper of the current active session.

### Issue 4 
The code persists a `yotpoToken` entry on the SMSSession. The value is actually a `YotpoAbandonedCartQuoteId`.
The term "token" is used incorrectly and conflicts with other entities, which are actually Yotpo tokens.
The key has been replaced with `yotpoQuoteToken`.