### PR TITLE
COR-1993 Refactor checkout sync flows

### DIFF
--- a/Model/Config.php
+++ b/Model/Config.php
@@ -27,6 +27,11 @@ class Config extends CoreConfig
     const YOTPO_CUSTOM_ATTRIBUTE_SMS_MARKETING = 'yotpo_accepts_sms_marketing';
 
     /**
+     * HTTP Request PATCH method string
+     */
+    const PATCH_METHOD_STRING = 'PATCH';
+
+    /**
      * @var string[]
      */
     protected $endPoints = [

--- a/Model/Sync/Checkout/Data.php
+++ b/Model/Sync/Checkout/Data.php
@@ -217,9 +217,9 @@ class Data
             if (!$address->getCountryId() && $quote->getIsVirtual()) {
                 $customer = $quote->getCustomer();
                 /** @phpstan-ignore-next-line */
-                $customerAddressId = $customer->getDefaultBilling();
-                if ($customerAddressId) {
-                    $address = $this->customerAddressRepository->getById($customerAddressId);
+                $defaultCustomerBillingAddressId = $customer->getDefaultBilling();
+                if ($defaultCustomerBillingAddressId) {
+                    $address = $this->customerAddressRepository->getById($defaultCustomerBillingAddressId);
                 }
             }
         } else {

--- a/Model/Sync/Checkout/Data.php
+++ b/Model/Sync/Checkout/Data.php
@@ -156,6 +156,7 @@ class Data
         if (!$billingAddressData || !$billingAddressData['country_code']) {
             return [];
         }
+
         $baseUrl = $this->storeManager->getStore()->getBaseUrl();
         $checkoutDate = $quote->getUpdatedAt() ?: $quote->getCreatedAt();
         if (!$quote->getCustomerIsGuest() && $quote->getCustomerId()) {
@@ -163,7 +164,8 @@ class Data
         } else {
             $isCustomerAcceptsSmsMarketing = (bool) $this->checkoutSession->getYotpoSmsMarketing();
         }
-        $data = [
+
+        $checkoutData = [
             'token' => $quote->getId(),
             'checkout_date' => $this->messagingDataHelper->formatDate($checkoutDate),
             'landing_site_url' => $baseUrl,
@@ -176,14 +178,15 @@ class Data
                 $this->storeManager->getStore()->getBaseUrl() . self::ABANDONED_URL . $quoteToken
         ];
         $dataBeforeChange = $this->getDataBeforeChange();
-        $newData = $data;
-        unset($newData['checkout_date']);
-        $newData = json_encode($newData);
-        if ($dataBeforeChange == $newData) {
+        $newCheckoutData = $checkoutData;
+        unset($newCheckoutData['checkout_date']);
+        $newCheckoutData = json_encode($newCheckoutData);
+        if ($dataBeforeChange == $newCheckoutData) {
             return [];//no change in quote data
         }
-        $this->checkoutSession->setYotpoCheckoutData($newData);
-        return ['checkout' => $data];
+
+        $this->checkoutSession->setYotpoCheckoutData($newCheckoutData);
+        return ['checkout' => $checkoutData];
     }
 
     /**

--- a/Model/Sync/Checkout/Data.php
+++ b/Model/Sync/Checkout/Data.php
@@ -11,6 +11,7 @@ use Magento\Customer\Api\AddressRepositoryInterface;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\GroupedProduct\Model\Product\Type\Grouped as ProductTypeGrouped;
+use Magento\Quote\Model\Quote\Address as QuoteAddress;
 use Magento\Quote\Model\Quote;
 use Magento\Quote\Model\Quote\Item;
 use Magento\SalesRule\Model\ResourceModel\Coupon\CollectionFactory as CouponCollectionFactory;
@@ -165,17 +166,7 @@ class Data
             'token' => $quote->getId(),
             'checkout_date' => $this->messagingDataHelper->formatDate($checkoutDate),
             'landing_site_url' => $baseUrl,
-            'customer' => [
-                'external_id' => $customerId ?: $customerEmail,
-                'email' => $customerEmail,
-                'phone_number' => $billingAddress->getTelephone() ? $this->messagingDataHelper->formatPhoneNumber(
-                    $billingAddress->getTelephone(),
-                    $billingAddress->getCountryId()
-                ) : null,
-                'first_name' => $customerData->getFirstname(),
-                'last_name' => $customerData->getLastname(),
-                'accepts_sms_marketing' => $isCustomerAcceptsSmsMarketing
-            ],
+            'customer' => $this->prepareCustomer($customerId, $customerEmail, $billingAddress, $customerData, $isCustomerAcceptsSmsMarketing),
             'billing_address' => $billingAddressData,
             'shipping_address' => $this->prepareShippingAddress($quote),
             'currency' => $quote->getCurrency() !== null ? $quote->getCurrency()->getQuoteCurrencyCode() : null,
@@ -331,5 +322,25 @@ class Data
             $product = $quoteItem->getProduct();
         }
         return $product;
+    }
+
+    /**
+     * @param string $customerId
+     * @param string $customerEmail
+     * @param QuoteAddress $billingAddress
+     * @param array $customerData
+     * @param boolean $isCustomerAcceptsSmsMarketing
+     * @return array
+     */
+    private function prepareCustomer($customerId, $customerEmail, $billingAddress, $customerData, $isCustomerAcceptsSmsMarketing)
+    {
+        return [
+            'external_id' => $customerId ?: $customerEmail,
+            'email' => $customerEmail,
+            'phone_number' => $this->abstractData->preparePhoneNumber($billingAddress),
+            'first_name' => $customerData->getFirstname(),
+            'last_name' => $customerData->getLastname(),
+            'accepts_sms_marketing' => $isCustomerAcceptsSmsMarketing
+        ];
     }
 }

--- a/Model/Sync/Checkout/Data.php
+++ b/Model/Sync/Checkout/Data.php
@@ -211,8 +211,9 @@ class Data
      */
     public function prepareBillingAddress(Quote $quote)
     {
-        $billingAddress = $quote->getData('newBillingAddress') ?: $quote->getBillingAddress();
-        if (!$billingAddress->getCountryId() && $quote->getIsVirtual()) {
+        $newBillingAddress = $quote->getData('newBillingAddress');
+        $billingAddress = $newBillingAddress ?: $quote->getBillingAddress();
+        if (!$newBillingAddress && $quote->getIsVirtual()) {
             $customer = $quote->getCustomer();
             /** @phpstan-ignore-next-line */
             $defaultCustomerBillingAddressId = $customer->getDefaultBilling();

--- a/Model/Sync/Checkout/Data.php
+++ b/Model/Sync/Checkout/Data.php
@@ -157,9 +157,9 @@ class Data
         $baseUrl = $this->storeManager->getStore()->getBaseUrl();
         $checkoutDate = $quote->getUpdatedAt() ?: $quote->getCreatedAt();
         if (!$quote->getCustomerIsGuest() && $quote->getCustomerId()) {
-            $customAttributeValue = $this->abstractData->getSmsMarketingCustomAttributeValue($customerId);
+            $isCustomerAcceptsSmsMarketing = $this->abstractData->getSmsMarketingCustomAttributeValue($customerId);
         } else {
-            $customAttributeValue = (bool) $this->checkoutSession->getYotpoSmsMarketing();
+            $isCustomerAcceptsSmsMarketing = (bool) $this->checkoutSession->getYotpoSmsMarketing();
         }
         $data = [
             'token' => $quote->getId(),
@@ -174,7 +174,7 @@ class Data
                 ) : null,
                 'first_name' => $customerData->getFirstname(),
                 'last_name' => $customerData->getLastname(),
-                'accepts_sms_marketing' => $customAttributeValue
+                'accepts_sms_marketing' => $isCustomerAcceptsSmsMarketing
             ],
             'billing_address' => $billingAddressData,
             'shipping_address' => $this->prepareAddress($quote, 'shipping'),

--- a/Model/Sync/Checkout/Data.php
+++ b/Model/Sync/Checkout/Data.php
@@ -252,32 +252,27 @@ class Data
         }
         try {
             foreach ($quote->getAllVisibleItems() as $item) {
-                try {
-                    $itemRuleIds = explode(',', $item->getAppliedRuleIds());
-                    if ($ruleId != null || !in_array($ruleId, $itemRuleIds)) {
-                        $couponCode = null;
-                    }
-                    $product = $this->prepareProductObject($item);
+                $itemRuleIds = explode(',', $item->getAppliedRuleIds());
+                if ($ruleId != null || !in_array($ruleId, $itemRuleIds)) {
+                    $couponCode = null;
+                }
+                $product = $this->prepareProductObject($item);
 
-                    $nonSimpleProductProductTypes = [ProductTypeGrouped::TYPE_CODE, ProductTypeGrouped::TYPE_CODE,
-                        ProductTypeConfigurable::TYPE_CODE, ProductTypeBundle::TYPE_CODE, $this::GIFTCARD_STRING];
-                    if (in_array($item->getProductType(), $nonSimpleProductProductTypes) && isset($lineItems[$product->getId()])) {
-                        $lineItems[$product->getId()]['total_price'] += $item->getData('row_total_incl_tax');
-                        $lineItems[$product->getId()]['subtotal_price'] += $item->getRowTotal();
-                        $lineItems[$product->getId()]['quantity'] += (integer)$item->getQty();
-                    } else {
-                        $this->lineItemsProductIds[] = $product->getId();
-                        $lineItems[$product->getId()] = [
-                            'external_product_id' => $product->getId(),
-                            'quantity' => (integer)$item->getQty(),
-                            'total_price' => $item->getData('row_total_incl_tax'),
-                            'subtotal_price' => $item->getRowTotal(),
-                            'coupon_code' => $couponCode
-                        ];
-                    }
-                } catch (\Exception $e) {
-                    $this->checkoutLogger->info('Checkout sync::prepareLineItems() - exception: ' .
-                        $e->getMessage(), []);
+                $nonSimpleProductProductTypes = [ProductTypeGrouped::TYPE_CODE, ProductTypeGrouped::TYPE_CODE,
+                    ProductTypeConfigurable::TYPE_CODE, ProductTypeBundle::TYPE_CODE, $this::GIFTCARD_STRING];
+                if (in_array($item->getProductType(), $nonSimpleProductProductTypes) && isset($lineItems[$product->getId()])) {
+                    $lineItems[$product->getId()]['total_price'] += $item->getData('row_total_incl_tax');
+                    $lineItems[$product->getId()]['subtotal_price'] += $item->getRowTotal();
+                    $lineItems[$product->getId()]['quantity'] += (integer)$item->getQty();
+                } else {
+                    $this->lineItemsProductIds[] = $product->getId();
+                    $lineItems[$product->getId()] = [
+                        'external_product_id' => $product->getId(),
+                        'quantity' => (integer)$item->getQty(),
+                        'total_price' => $item->getData('row_total_incl_tax'),
+                        'subtotal_price' => $item->getRowTotal(),
+                        'coupon_code' => $couponCode
+                    ];
                 }
             }
         } catch (\Exception $e) {

--- a/Model/Sync/Checkout/Data.php
+++ b/Model/Sync/Checkout/Data.php
@@ -279,8 +279,13 @@ class Data
                 }
             }
         } catch (\Exception $e) {
-            $this->checkoutLogger->info('Checkout sync::prepareLineItems() - exception: ' .
-                $e->getMessage(), []);
+            $this->checkoutLogger->info(
+                __(
+                    'Failed to sync Checkout when preparing line items for sync - Checkout ID: %1, Error Message: %2',
+                    $quote->getId(),
+                    $e->getMessage()
+                )
+            );
         }
         return $lineItems;
     }

--- a/Model/Sync/Checkout/Data.php
+++ b/Model/Sync/Checkout/Data.php
@@ -14,7 +14,7 @@ use Magento\GroupedProduct\Model\Product\Type\Grouped as ProductTypeGrouped;
 use Magento\Quote\Model\Quote;
 use Magento\Quote\Model\Quote\Item;
 use Magento\SalesRule\Model\ResourceModel\Coupon\CollectionFactory as CouponCollectionFactory;
-use Yotpo\SmsBump\Helper\Data as SMSHelper;
+use Yotpo\SmsBump\Helper\Data as MessagingDataHelper;
 use Magento\Checkout\Model\Session as CheckoutSession;
 use Magento\Store\Model\StoreManagerInterface;
 use Yotpo\SmsBump\Model\Sync\Data\AbstractData;
@@ -27,9 +27,9 @@ class Data
 {
     const ABANDONED_URL = 'yotpo_messaging/abandonedcart/loadcart/yotpoQuoteToken/';
     /**
-     * @var SMSHelper
+     * @var MessagingDataHelper
      */
-    protected $smsHelper;
+    protected $messagingDataHelper;
 
     /**
      * @var CheckoutSession
@@ -88,7 +88,7 @@ class Data
 
     /**
      * Data constructor.
-     * @param SMSHelper $smsHelper
+     * @param MessagingDataHelper $smsHelper
      * @param CheckoutSession $checkoutSession
      * @param StoreManagerInterface $storeManager
      * @param CouponCollectionFactory $couponCollectionFactory
@@ -99,7 +99,7 @@ class Data
      * @param AbandonedCartData $abandonedCartData
      */
     public function __construct(
-        SMSHelper $smsHelper,
+        MessagingDataHelper $messagingDataHelper,
         CheckoutSession $checkoutSession,
         StoreManagerInterface $storeManager,
         CouponCollectionFactory $couponCollectionFactory,
@@ -109,7 +109,7 @@ class Data
         AddressRepositoryInterface $customerAddressRepository,
         AbandonedCartData $abandonedCartData
     ) {
-        $this->smsHelper = $smsHelper;
+        $this->messagingDataHelper = $messagingDataHelper;
         $this->checkoutSession = $checkoutSession;
         $this->storeManager = $storeManager;
         $this->couponCollectionFactory = $couponCollectionFactory;
@@ -163,12 +163,12 @@ class Data
         }
         $data = [
             'token' => $quote->getId(),
-            'checkout_date' => $this->smsHelper->formatDate($checkoutDate),
+            'checkout_date' => $this->messagingDataHelper->formatDate($checkoutDate),
             'landing_site_url' => $baseUrl,
             'customer' => [
                 'external_id' => $customerId ?: $customerEmail,
                 'email' => $customerEmail,
-                'phone_number' => $billingAddress->getTelephone() ? $this->smsHelper->formatPhoneNumber(
+                'phone_number' => $billingAddress->getTelephone() ? $this->messagingDataHelper->formatPhoneNumber(
                     $billingAddress->getTelephone(),
                     $billingAddress->getCountryId()
                 ) : null,

--- a/Model/Sync/Checkout/Data.php
+++ b/Model/Sync/Checkout/Data.php
@@ -27,6 +27,7 @@ use Yotpo\SmsBump\Model\AbandonedCart\Data as AbandonedCartData;
 class Data
 {
     const ABANDONED_URL = 'yotpo_messaging/abandonedcart/loadcart/yotpoQuoteToken/';
+    const GIFTCARD_STRING = 'giftcard';
     /**
      * @var MessagingDataHelper
      */
@@ -258,13 +259,10 @@ class Data
                     }
                     $product = $this->prepareProductObject($item);
 
-                    if (($item->getProductType() === ProductTypeGrouped::TYPE_CODE
-                            || $item->getProductType() === ProductTypeConfigurable::TYPE_CODE
-                            || $item->getProductType() === ProductTypeBundle::TYPE_CODE
-                            || $item->getProductType() === 'giftcard')
-                        && (isset($lineItems[$product->getId()]))) {
-                        $lineItems[$product->getId()]['total_price'] +=
-                            $item->getData('row_total_incl_tax');
+                    $nonSimpleProductProductTypes = [ProductTypeGrouped::TYPE_CODE, ProductTypeGrouped::TYPE_CODE,
+                        ProductTypeConfigurable::TYPE_CODE, ProductTypeBundle::TYPE_CODE, $this::GIFTCARD_STRING];
+                    if (in_array($item->getProductType(), $nonSimpleProductProductTypes) && isset($lineItems[$product->getId()])) {
+                        $lineItems[$product->getId()]['total_price'] += $item->getData('row_total_incl_tax');
                         $lineItems[$product->getId()]['subtotal_price'] += $item->getRowTotal();
                         $lineItems[$product->getId()]['quantity'] += (integer)$item->getQty();
                     } else {
@@ -281,7 +279,6 @@ class Data
                     $this->checkoutLogger->info('Checkout sync::prepareLineItems() - exception: ' .
                         $e->getMessage(), []);
                 }
-
             }
         } catch (\Exception $e) {
             $this->checkoutLogger->info('Checkout sync::prepareLineItems() - exception: ' .

--- a/Model/Sync/Checkout/Data.php
+++ b/Model/Sync/Checkout/Data.php
@@ -144,6 +144,12 @@ class Data
             }
         }
         if (!$customerId && !$customerEmail) {
+            $this->checkoutLogger->info(
+                __(
+                    'Did not sync Checkout to Yotpo - Checkout event without address data - Checkout ID: %1',
+                    $quote->getId()
+                )
+            );
             return [];
         }
 
@@ -154,6 +160,13 @@ class Data
 
         $billingAddressData = $this->prepareBillingAddress($quote);
         if (!$billingAddressData || !$billingAddressData['country_code']) {
+            $this->checkoutLogger->info(
+                __(
+                    'Failed to sync Checkout to Yotpo - Billing Address didn\'t contain valid Country ID - Checkout ID: %1, Country ID: %2',
+                    $quote->getId(),
+                    $quote->getBillingAddress()->getCountryId()
+                )
+            );
             return [];
         }
 
@@ -182,6 +195,12 @@ class Data
         unset($newCheckoutData['checkout_date']);
         $newCheckoutData = json_encode($newCheckoutData);
         if ($dataBeforeChange == $newCheckoutData) {
+            $this->checkoutLogger->info(
+                __(
+                    'Did not sync Checkout to Yotpo - No new data was found - Checkout ID: %1',
+                    $quote->getId()
+                )
+            );
             return [];//no change in quote data
         }
 

--- a/Model/Sync/Checkout/Data.php
+++ b/Model/Sync/Checkout/Data.php
@@ -257,6 +257,7 @@ class Data
                         $couponCode = null;
                     }
                     $product = $this->prepareProductObject($item);
+
                     if (($item->getProductType() === ProductTypeGrouped::TYPE_CODE
                             || $item->getProductType() === ProductTypeConfigurable::TYPE_CODE
                             || $item->getProductType() === ProductTypeBundle::TYPE_CODE
@@ -265,12 +266,12 @@ class Data
                         $lineItems[$product->getId()]['total_price'] +=
                             $item->getData('row_total_incl_tax');
                         $lineItems[$product->getId()]['subtotal_price'] += $item->getRowTotal();
-                        $lineItems[$product->getId()]['quantity'] += $item->getQty() * 1;
+                        $lineItems[$product->getId()]['quantity'] += (integer)$item->getQty();
                     } else {
                         $this->lineItemsProductIds[] = $product->getId();
                         $lineItems[$product->getId()] = [
                             'external_product_id' => $product->getId(),
-                            'quantity' => $item->getQty() * 1,
+                            'quantity' => (integer)$item->getQty(),
                             'total_price' => $item->getData('row_total_incl_tax'),
                             'subtotal_price' => $item->getRowTotal(),
                             'coupon_code' => $couponCode

--- a/Model/Sync/Checkout/Processor.php
+++ b/Model/Sync/Checkout/Processor.php
@@ -7,7 +7,7 @@ use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Quote\Model\Quote;
 use Yotpo\SmsBump\Model\Sync\Main;
-use Yotpo\SmsBump\Model\Config;
+use Yotpo\SmsBump\Model\Config as YotpoMessagingConfig;
 use Yotpo\SmsBump\Model\Sync\Checkout\Data as CheckoutData;
 use Yotpo\SmsBump\Model\Sync\Checkout\Logger as YotpoCheckoutLogger;
 use Yotpo\SmsBump\Helper\Data as SMSHelper;
@@ -25,9 +25,9 @@ class Processor
     protected $yotpoSyncMain;
 
     /**
-     * @var Config
+     * @var YotpoMessagingConfig
      */
-    protected $yotpoSmsConfig;
+    protected $yotpoMessagingConfig;
 
     /**
      * @var Data
@@ -58,7 +58,7 @@ class Processor
     /**
      * Processor constructor.
      * @param Main $yotpoSyncMain
-     * @param Config $yotpoSmsConfig
+     * @param YotpoMessagingConfig $yotpoMessagingConfig
      * @param Data $checkoutData
      * @param Logger $yotpoCheckoutLogger
      * @param SMSHelper $smsHelper
@@ -66,14 +66,14 @@ class Processor
      */
     public function __construct(
         Main $yotpoSyncMain,
-        Config $yotpoSmsConfig,
+        YotpoMessagingConfig $yotpoMessagingConfig,
         CheckoutData $checkoutData,
         YotpoCheckoutLogger $yotpoCheckoutLogger,
         SMSHelper $smsHelper,
         CatalogProcessor $catalogProcessor
     ) {
         $this->yotpoSyncMain = $yotpoSyncMain;
-        $this->yotpoSmsConfig = $yotpoSmsConfig;
+        $this->yotpoMessagingConfig = $yotpoMessagingConfig;
         $this->checkoutData = $checkoutData;
         $this->yotpoCheckoutLogger = $yotpoCheckoutLogger;
         $this->smsHelper = $smsHelper;
@@ -90,7 +90,7 @@ class Processor
      */
     public function process(Quote $quote)
     {
-        $isCheckoutSyncEnabled = $this->yotpoSmsConfig->isCheckoutSyncActive();
+        $isCheckoutSyncEnabled = $this->yotpoMessagingConfig->isCheckoutSyncActive();
         if ($isCheckoutSyncEnabled) {
             $newCheckoutData = $this->checkoutData->prepareData($quote);
             $this->yotpoCheckoutLogger->info('Checkout sync - data prepared', []);
@@ -111,7 +111,7 @@ class Processor
             }
 
             $method = self::PATCH_METHOD_STRING;
-            $url = $this->yotpoSmsConfig->getEndpoint('checkout');
+            $url = $this->yotpoMessagingConfig->getEndpoint('checkout');
             $newCheckoutData['entityLog'] = 'checkout';
             $syncCheckoutResult = $this->yotpoSyncMain->sync($method, $url, $newCheckoutData, 'api', true);
             if ($syncCheckoutResult->getData(self::IS_SUCCESS_MESSAGE_KEY)) {
@@ -131,7 +131,7 @@ class Processor
      */
     public function updateLastSyncDate()
     {
-        $this->yotpoSmsConfig->saveConfig('checkout_last_sync_time', date('Y-m-d H:i:s'));
+        $this->yotpoMessagingConfig->saveConfig('checkout_last_sync_time', date('Y-m-d H:i:s'));
     }
 
     /**

--- a/Model/Sync/Checkout/Processor.php
+++ b/Model/Sync/Checkout/Processor.php
@@ -37,7 +37,7 @@ class Processor
     /**
      * @var Logger
      */
-    protected $yotpoChekoutLogger;
+    protected $yotpoCheckoutLogger;
 
     /**
      * @var SMSHelper
@@ -60,7 +60,7 @@ class Processor
      * @param Main $yotpoSyncMain
      * @param Config $yotpoSmsConfig
      * @param Data $checkoutData
-     * @param Logger $yotpoChekoutLogger
+     * @param Logger $yotpoCheckoutLogger
      * @param SMSHelper $smsHelper
      * @param CatalogProcessor $catalogProcessor
      */
@@ -68,14 +68,14 @@ class Processor
         Main $yotpoSyncMain,
         Config $yotpoSmsConfig,
         CheckoutData $checkoutData,
-        YotpoCheckoutLogger $yotpoChekoutLogger,
+        YotpoCheckoutLogger $yotpoCheckoutLogger,
         SMSHelper $smsHelper,
         CatalogProcessor $catalogProcessor
     ) {
         $this->yotpoSyncMain = $yotpoSyncMain;
         $this->yotpoSmsConfig = $yotpoSmsConfig;
         $this->checkoutData = $checkoutData;
-        $this->yotpoChekoutLogger = $yotpoChekoutLogger;
+        $this->yotpoCheckoutLogger = $yotpoCheckoutLogger;
         $this->smsHelper = $smsHelper;
         $this->catalogProcessor = $catalogProcessor;
     }
@@ -93,10 +93,10 @@ class Processor
         $isCheckoutSyncEnabled = $this->yotpoSmsConfig->isCheckoutSyncActive();
         if ($isCheckoutSyncEnabled) {
             $newCheckoutData = $this->checkoutData->prepareData($quote);
-            $this->yotpoChekoutLogger->info('Checkout sync - data prepared', []);
+            $this->yotpoCheckoutLogger->info('Checkout sync - data prepared', []);
 
             if (!$newCheckoutData) {
-                $this->yotpoChekoutLogger->info('Checkout sync - no new data to sync', []);
+                $this->yotpoCheckoutLogger->info('Checkout sync - no new data to sync', []);
                 return;
             }
             $productIds = $this->checkoutData->getLineItemsIds();
@@ -105,7 +105,7 @@ class Processor
                 $storeId = $quote->getStoreId();
                 $isProductSyncSuccess = $this->catalogProcessor->syncProducts($productIds, $visibleItems, $storeId);
                 if (!$isProductSyncSuccess) {
-                    $this->yotpoChekoutLogger->info('Products sync failed in checkout', []);
+                    $this->yotpoCheckoutLogger->info('Products sync failed in checkout', []);
                     return;
                 }
             }
@@ -116,7 +116,7 @@ class Processor
             $syncCheckoutResult = $this->yotpoSyncMain->sync($method, $url, $newCheckoutData, 'api', true);
             if ($syncCheckoutResult->getData(self::IS_SUCCESS_MESSAGE_KEY)) {
                 $this->updateLastSyncDate();
-                $this->yotpoChekoutLogger->info('Checkout sync - success', []);
+                $this->yotpoCheckoutLogger->info('Checkout sync - success', []);
             } else {
                 $this->logCheckoutSyncFailure($syncCheckoutResult);
             }
@@ -144,6 +144,6 @@ class Processor
         $failureReason = $syncResult->getData(self::REASON_KEY);
         $innerResponse = $syncResult->getData(self::RESPONSE_KEY);
 
-        $this->yotpoChekoutLogger->info('Checkout sync - failed', [$statusCode, $failureReason, $innerResponse]);
+        $this->yotpoCheckoutLogger->info('Checkout sync - failed', [$statusCode, $failureReason, $innerResponse]);
     }
 }

--- a/Model/Sync/Checkout/Processor.php
+++ b/Model/Sync/Checkout/Processor.php
@@ -10,7 +10,7 @@ use Yotpo\SmsBump\Model\Sync\Main;
 use Yotpo\SmsBump\Model\Config as YotpoMessagingConfig;
 use Yotpo\SmsBump\Model\Sync\Checkout\Data as CheckoutData;
 use Yotpo\SmsBump\Model\Sync\Checkout\Logger as YotpoCheckoutLogger;
-use Yotpo\SmsBump\Helper\Data as SMSHelper;
+use Yotpo\SmsBump\Helper\Data as MessagingDataHelper;
 use Yotpo\Core\Model\Sync\Catalog\Processor as CatalogProcessor;
 
 /**
@@ -40,9 +40,9 @@ class Processor
     protected $yotpoCheckoutLogger;
 
     /**
-     * @var SMSHelper
+     * @var MessagingDataHelper
      */
-    protected $smsHelper;
+    protected $messagingDataHelper;
 
     /**
      * @var CatalogProcessor
@@ -60,7 +60,7 @@ class Processor
      * @param YotpoMessagingConfig $yotpoMessagingConfig
      * @param Data $checkoutData
      * @param Logger $yotpoCheckoutLogger
-     * @param SMSHelper $smsHelper
+     * @param MessagingDataHelper $messagingDataHelper
      * @param CatalogProcessor $catalogProcessor
      */
     public function __construct(
@@ -68,14 +68,14 @@ class Processor
         YotpoMessagingConfig $yotpoMessagingConfig,
         CheckoutData $checkoutData,
         YotpoCheckoutLogger $yotpoCheckoutLogger,
-        SMSHelper $smsHelper,
+        MessagingDataHelper $messagingDataHelper,
         CatalogProcessor $catalogProcessor
     ) {
         $this->yotpoSyncMain = $yotpoSyncMain;
         $this->yotpoMessagingConfig = $yotpoMessagingConfig;
         $this->checkoutData = $checkoutData;
         $this->yotpoCheckoutLogger = $yotpoCheckoutLogger;
-        $this->smsHelper = $smsHelper;
+        $this->messagingDataHelper = $messagingDataHelper;
         $this->catalogProcessor = $catalogProcessor;
     }
 

--- a/Model/Sync/Checkout/Processor.php
+++ b/Model/Sync/Checkout/Processor.php
@@ -49,10 +49,10 @@ class Processor
      */
     protected $catalogProcessor;
 
-    const IS_SUCCESS_MESSAGE_KEY = 'is_success';
-    const STATUS_CODE_KEY = 'status';
-    const RESPONSE_KEY = 'response';
-    const REASON_KEY = 'reason';
+    const SYNC_RESULT_IS_SUCCESS_KEY = 'is_success';
+    const SYNC_RESULT_STATUS_CODE_KEY = 'status';
+    const SYNC_RESULT_RESPONSE_KEY = 'response';
+    const SYNC_RESULT_REASON_KEY = 'reason';
 
     /**
      * Processor constructor.
@@ -113,7 +113,7 @@ class Processor
             $url = $this->yotpoMessagingConfig->getEndpoint('checkout');
             $newCheckoutData['entityLog'] = 'checkout';
             $syncCheckoutResult = $this->yotpoSyncMain->sync($method, $url, $newCheckoutData, 'api', true);
-            if ($syncCheckoutResult->getData(self::IS_SUCCESS_MESSAGE_KEY)) {
+            if ($syncCheckoutResult->getData(self::SYNC_RESULT_IS_SUCCESS_KEY)) {
                 $this->updateLastSyncDate();
                 $this->yotpoCheckoutLogger->info('Checkout sync - success', []);
             } else {
@@ -139,9 +139,9 @@ class Processor
      */
     private function logCheckoutSyncFailure($syncResult)
     {
-        $statusCode = $syncResult->getData(self::STATUS_CODE_KEY);
-        $failureReason = $syncResult->getData(self::REASON_KEY);
-        $innerResponse = $syncResult->getData(self::RESPONSE_KEY);
+        $statusCode = $syncResult->getData(self::SYNC_RESULT_STATUS_CODE_KEY);
+        $failureReason = $syncResult->getData(self::SYNC_RESULT_REASON_KEY);
+        $innerResponse = $syncResult->getData(self::SYNC_RESULT_RESPONSE_KEY);
 
         $this->yotpoCheckoutLogger->info('Checkout sync - failed', [$statusCode, $failureReason, $innerResponse]);
     }

--- a/Model/Sync/Checkout/Processor.php
+++ b/Model/Sync/Checkout/Processor.php
@@ -95,7 +95,6 @@ class Processor
             $this->yotpoCheckoutLogger->info('Checkout sync to Yotpo - finished preparing checkout data for sync');
 
             if (!$newCheckoutData) {
-                $this->yotpoCheckoutLogger->info('Checkout sync to Yotpo - no new data to sync');
                 return;
             }
             $productIds = $this->checkoutData->getLineItemsIds();

--- a/Model/Sync/Checkout/Processor.php
+++ b/Model/Sync/Checkout/Processor.php
@@ -49,7 +49,6 @@ class Processor
      */
     protected $catalogProcessor;
 
-    const PATCH_METHOD_STRING = 'PATCH';
     const IS_SUCCESS_MESSAGE_KEY = 'is_success';
     const STATUS_CODE_KEY = 'status';
     const RESPONSE_KEY = 'response';
@@ -110,7 +109,7 @@ class Processor
                 }
             }
 
-            $method = self::PATCH_METHOD_STRING;
+            $method = $this->yotpoMessagingConfig::PATCH_METHOD_STRING;
             $url = $this->yotpoMessagingConfig->getEndpoint('checkout');
             $newCheckoutData['entityLog'] = 'checkout';
             $syncCheckoutResult = $this->yotpoSyncMain->sync($method, $url, $newCheckoutData, 'api', true);

--- a/Model/Sync/Checkout/Processor.php
+++ b/Model/Sync/Checkout/Processor.php
@@ -92,10 +92,10 @@ class Processor
         $isCheckoutSyncEnabled = $this->yotpoMessagingConfig->isCheckoutSyncActive();
         if ($isCheckoutSyncEnabled) {
             $newCheckoutData = $this->checkoutData->prepareData($quote);
-            $this->yotpoCheckoutLogger->info('Checkout sync - data prepared', []);
+            $this->yotpoCheckoutLogger->info('Checkout sync to Yotpo - finished preparing checkout data for sync');
 
             if (!$newCheckoutData) {
-                $this->yotpoCheckoutLogger->info('Checkout sync - no new data to sync', []);
+                $this->yotpoCheckoutLogger->info('Checkout sync to Yotpo - no new data to sync');
                 return;
             }
             $productIds = $this->checkoutData->getLineItemsIds();
@@ -104,7 +104,13 @@ class Processor
                 $storeId = $quote->getStoreId();
                 $isProductSyncSuccess = $this->catalogProcessor->syncProducts($productIds, $visibleItems, $storeId);
                 if (!$isProductSyncSuccess) {
-                    $this->yotpoCheckoutLogger->info('Products sync failed in checkout', []);
+                    $this->yotpoCheckoutLogger->info(
+                        __(
+                            'Failed to sync Checkout to Yotpo - products sync to Yotpo failed - Store ID: %1, Products IDs: %2',
+                            $storeId,
+                            $productIds
+                        )
+                    );
                     return;
                 }
             }
@@ -115,7 +121,7 @@ class Processor
             $syncCheckoutResult = $this->yotpoSyncMain->sync($method, $url, $newCheckoutData, 'api', true);
             if ($syncCheckoutResult->getData(self::SYNC_RESULT_IS_SUCCESS_KEY)) {
                 $this->updateLastSyncDate();
-                $this->yotpoCheckoutLogger->info('Checkout sync - success', []);
+                $this->yotpoCheckoutLogger->info('Checkout sync to Yotpo - finished successfully');
             } else {
                 $this->logCheckoutSyncFailure($syncCheckoutResult);
             }
@@ -143,6 +149,13 @@ class Processor
         $failureReason = $syncResult->getData(self::SYNC_RESULT_REASON_KEY);
         $innerResponse = $syncResult->getData(self::SYNC_RESULT_RESPONSE_KEY);
 
-        $this->yotpoCheckoutLogger->info('Checkout sync - failed', [$statusCode, $failureReason, $innerResponse]);
+        $this->yotpoCheckoutLogger->info(
+            __(
+                'Failed to sync Checkout to Yotpo - Status Code: %1, Failure Reason: %2, Response: %3',
+                $statusCode,
+                $failureReason,
+                $innerResponse
+            )
+        );
     }
 }

--- a/Model/Sync/Data/AbstractData.php
+++ b/Model/Sync/Data/AbstractData.php
@@ -91,6 +91,7 @@ class AbstractData
             $state = $address->getRegion();
             $provinceCode = $address->getRegionCode();
         }
+
         $street = $address->getStreet();
         return [
             'address1' => is_array($street) && count($street) >= 1 ? $street[0] : $street,
@@ -101,10 +102,19 @@ class AbstractData
             'zip' => $address->getPostcode(),
             'province_code' => $provinceCode,
             'country_code' => $address->getCountryId(),
-            'phone_number' => $address->getTelephone() ? $this->messagingDataHelper->formatPhoneNumber(
-                $address->getTelephone(),
-                $address->getCountryId()
-            ) : null
+            'phone_number' => $this->preparePhoneNumber($address)
         ];
+    }
+
+    /**
+     * @param QuoteAddress|CustomerAddress $address
+     * @return string|null
+     */
+    public function preparePhoneNumber($address)
+    {
+        return $address->getTelephone() ? $this->messagingDataHelper->formatPhoneNumber(
+            $address->getTelephone(),
+            $address->getCountryId()
+        ) : null;
     }
 }

--- a/Model/Sync/Data/AbstractData.php
+++ b/Model/Sync/Data/AbstractData.php
@@ -54,14 +54,14 @@ class AbstractData
      */
     public function getSmsMarketingCustomAttributeValue($customerId)
     {
-        $customAttributeValue = false;
+        $isAcceptsSmsMarketing = false;
         $attributeCode = $this->config->getConfig('sms_marketing_custom_attribute', $this->config->getStoreId());
         $customAttribute = $this->customerRepository->getById($customerId)
             ->getCustomAttribute($attributeCode);
         if ($customAttribute) {
-            $customAttributeValue = $customAttribute->getValue();
+            $isAcceptsSmsMarketing = $customAttribute->getValue();
         }
-        return $customAttributeValue == 1;
+        return $isAcceptsSmsMarketing == 1;
     }
 
     /**

--- a/Model/Sync/Data/AbstractData.php
+++ b/Model/Sync/Data/AbstractData.php
@@ -8,7 +8,7 @@ use Magento\Framework\Exception\NoSuchEntityException;
 use Yotpo\SmsBump\Model\Config;
 use Magento\Quote\Model\Quote\Address as QuoteAddress;
 use Magento\Customer\Model\Address as CustomerAddress;
-use Yotpo\SmsBump\Helper\Data as SMSHelper;
+use Yotpo\SmsBump\Helper\Data as MessagingDataHelper;
 
 /**
  * Class AbstractData for common methods
@@ -21,9 +21,9 @@ class AbstractData
     protected $customerRepository;
 
     /**
-     * @var SMSHelper
+     * @var MessagingDataHelper
      */
-    protected $smsHelper;
+    protected $messagingDataHelper;
 
     /**
      * @var Config
@@ -33,16 +33,16 @@ class AbstractData
     /**
      * AbstractData constructor.
      * @param CustomerRepositoryInterface $customerRepository
-     * @param SMSHelper $smsHelper
+     * @param MessagingDataHelper $messagingDataHelper
      * @param Config $config
      */
     public function __construct(
         CustomerRepositoryInterface $customerRepository,
-        SMShelper $smsHelper,
+        MessagingDataHelper $messagingDataHelper,
         Config $config
     ) {
         $this->customerRepository = $customerRepository;
-        $this->smsHelper = $smsHelper;
+        $this->messagingDataHelper = $messagingDataHelper;
         $this->config = $config;
     }
 
@@ -101,7 +101,7 @@ class AbstractData
             'zip' => $address->getPostcode(),
             'province_code' => $provinceCode,
             'country_code' => $address->getCountryId(),
-            'phone_number' => $address->getTelephone() ? $this->smsHelper->formatPhoneNumber(
+            'phone_number' => $address->getTelephone() ? $this->messagingDataHelper->formatPhoneNumber(
                 $address->getTelephone(),
                 $address->getCountryId()
             ) : null

--- a/Model/Sync/Data/AbstractData.php
+++ b/Model/Sync/Data/AbstractData.php
@@ -61,7 +61,7 @@ class AbstractData
         if ($customAttribute) {
             $isAcceptsSmsMarketing = $customAttribute->getValue();
         }
-        return $isAcceptsSmsMarketing == 1;
+        return (bool) $isAcceptsSmsMarketing;
     }
 
     /**

--- a/Plugin/Customer/Account/LoginPost.php
+++ b/Plugin/Customer/Account/LoginPost.php
@@ -24,7 +24,7 @@ class LoginPost
     /**
      * @var UrlInterface
      */
-    protected $url;
+    protected $urlInterface;
 
     /**
      * @var Session
@@ -39,18 +39,18 @@ class LoginPost
     /**
      * LoginPost constructor.
      * @param RedirectFactory $resultRedirectFactory
-     * @param UrlInterface $url
+     * @param UrlInterface $urlInterface
      * @param Session $session
      * @param AbandonedCartData $abandonedCartData
      */
     public function __construct(
         RedirectFactory $resultRedirectFactory,
-        UrlInterface $url,
+        UrlInterface $urlInterface,
         Session $session,
         AbandonedCartData $abandonedCartData
     ) {
         $this->resultRedirectFactory = $resultRedirectFactory;
-        $this->url = $url;
+        $this->urlInterface = $urlInterface;
         $this->session = $session;
         $this->abandonedCartData = $abandonedCartData;
     }
@@ -68,7 +68,7 @@ class LoginPost
             return $result;
         }
 
-        $customRedirectionUrl = $this->url->getUrl('checkout', ['_fragment' => 'payment']);
+        $customRedirectionUrl = $this->urlInterface->getUrl('checkout', ['_fragment' => 'payment']);
         $yotpoQuoteToken = $this->abandonedCartData->getYotpoQuoteToken();
         if ($yotpoQuoteToken) {
             $this->abandonedCartData->setQuoteData($yotpoQuoteToken);

--- a/Plugin/Quote/Model/Cart/CartTotalRepository.php
+++ b/Plugin/Quote/Model/Cart/CartTotalRepository.php
@@ -37,7 +37,7 @@ class CartTotalRepository
     /**
      * @var Config
      */
-    protected $yotpoSmsConfig;
+    protected $yotpoMessagingConfig;
 
     /**
      * @var UrlInterface
@@ -49,20 +49,20 @@ class CartTotalRepository
      * @param CheckoutProcessor $checkoutProcessor
      * @param CartRepositoryInterface $quoteRepository
      * @param RequestInterface $request
-     * @param Config $yotpoSmsConfig
+     * @param Config $yotpoMessagingConfig
      * @param UrlInterface $urlInterface
      */
     public function __construct(
         CheckoutProcessor $checkoutProcessor,
         CartRepositoryInterface $quoteRepository,
         RequestInterface $request,
-        Config $yotpoSmsConfig,
+        Config $yotpoMessagingConfig,
         UrlInterface $urlInterface
     ) {
         $this->checkoutProcessor = $checkoutProcessor;
         $this->quoteRepository = $quoteRepository;
         $this->request = $request;
-        $this->yotpoSmsConfig = $yotpoSmsConfig;
+        $this->yotpoMessagingConfig = $yotpoMessagingConfig;
         $this->urlInterface = $urlInterface;
     }
 
@@ -81,7 +81,7 @@ class CartTotalRepository
     ) {
         $currentUrl = $this->urlInterface->getCurrentUrl();
         $allowedUrls = ['/shipping-information','/totals'];
-        $allowedUrlsFromConfig = $this->yotpoSmsConfig->getConfig('checkout_sync_allowed_urls');
+        $allowedUrlsFromConfig = $this->yotpoMessagingConfig->getConfig('checkout_sync_allowed_urls');
         if ($allowedUrlsFromConfig) {
             $allowedUrlConfigValues = explode(',', $allowedUrlsFromConfig);
             $allowedUrlConfigValues = array_map('trim', $allowedUrlConfigValues);
@@ -103,7 +103,7 @@ class CartTotalRepository
         if (!$urlFound) {
             return $result;
         }
-        if ($this->yotpoSmsConfig->isCheckoutSyncActive()) {
+        if ($this->yotpoMessagingConfig->isCheckoutSyncActive()) {
             /** @var Quote $quote */
             $quote = $this->quoteRepository->getActive($cartId);
             $this->checkoutProcessor->process($quote);


### PR DESCRIPTION
**Moved to #92** 

## PR Description ##
This PR is for refactoring Checkout sync flows containing refactoring commits for extracting to methods and reuse, readability and performance, this PR contain mostly renaming, extracting logic to shared private methods, reducing unneeded code, and adding and enhancing logs entries and logs messages explanations.

## Developer Notes ##
Few questions regarding Checkout syncing:
1. Do we really need to assert on address->CountryId for not being found for the condition in CheckoutData#prepareAddress ? Is there any occasion where address doesn't have country id? https://github.com/YotpoLtd/magento2-module-messaging/blob/a2e6474a291b88f09fccc815a222a5cfca576d2c/Model/Sync/Checkout/Data.php#L217 2.
2. Doesn't the value on the last item in the list, will be set as the rule id in CheckoutData#prepareLineItems ? Is this by design?  
https://github.com/YotpoLtd/magento2-module-messaging/blob/master/Model/Sync/Checkout/Data.php#L247 3.
3. (Product question) should we have failover for Checkout failures? Currently if a Checkout sync failed, we lose the checkout data 