### PR TITLE
COR-2003 customers sync flows revamp

### DIFF
--- a/Model/Config.php
+++ b/Model/Config.php
@@ -32,6 +32,16 @@ class Config extends CoreConfig
     const SYNCED_TO_YOTPO_CUSTOMER_ATTRIBUTE_NAME = 'synced_to_yotpo_customer';
 
     /**
+     * Customer entity int table name
+     */
+    const CUSTOMER_ENTITY_INT_TABLE_NAME = 'customer_entity_int';
+
+    /**
+     * Yotpo customers sync table name
+     */
+    const YOTPO_CUSTOMERS_SYNC_TABLE_NAME = 'yotpo_customers_sync';
+
+    /**
      * HTTP Request PATCH method string
      */
     const PATCH_METHOD_STRING = 'PATCH';

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -27,6 +27,11 @@ class Config extends CoreConfig
     const YOTPO_CUSTOM_ATTRIBUTE_SMS_MARKETING = 'yotpo_accepts_sms_marketing';
 
     /**
+     * Custom Customer attribute name for synced to yotpo customer
+     */
+    const SYNCED_TO_YOTPO_CUSTOMER_ATTRIBUTE_NAME = 'synced_to_yotpo_customer';
+
+    /**
      * HTTP Request PATCH method string
      */
     const PATCH_METHOD_STRING = 'PATCH';

--- a/Model/Config/Backend/Sync/CustomersScheduler.php
+++ b/Model/Config/Backend/Sync/CustomersScheduler.php
@@ -71,18 +71,27 @@ class CustomersScheduler extends ConfigValue
     {
         $customersCronExpressionString = $this->getData('groups/sync_settings/groups/customers_sync/fields/frequency/value');
         try {
-            /** @phpstan-ignore-next-line */
-            $this->_configValueFactory->create()->load(
-                self::YOTPO_MESSAGING_CUSTOMERS_SYNC_CRON_EXPRESSION_PATH,
-                'path'
-            )->setValue(
-                $customersCronExpressionString
-            )->setPath(
-                self::YOTPO_MESSAGING_CUSTOMERS_SYNC_CRON_EXPRESSION_PATH
-            )->save();
+            $this->configureCronCustomersSync($customersCronExpressionString);
         } catch (\Exception $exception) {
             throw new AlreadyExistsException(__('We can\'t save the cron expression.'));
         }
         return parent::afterSave();
+    }
+
+    /**
+     * @param $customersCronExpressionString
+     * @return void
+     */
+    private function configureCronCustomersSync($customersCronExpressionString)
+    {
+        /** @phpstan-ignore-next-line */
+        $this->_configValueFactory->create()->load(
+            self::YOTPO_MESSAGING_CUSTOMERS_SYNC_CRON_EXPRESSION_PATH,
+            'path'
+        )->setValue(
+            $customersCronExpressionString
+        )->setPath(
+            self::YOTPO_MESSAGING_CUSTOMERS_SYNC_CRON_EXPRESSION_PATH
+        )->save();
     }
 }

--- a/Model/Config/Backend/Sync/CustomersScheduler.php
+++ b/Model/Config/Backend/Sync/CustomersScheduler.php
@@ -25,6 +25,11 @@ class CustomersScheduler extends ConfigValue
     const YOTPO_MESSAGING_CUSTOMERS_SYNC_CRON_EXPRESSION_PATH = 'crontab/yotpo_messaging_customers_sync/jobs/yotpo_cron_messaging_customers_sync/schedule/cron_expr';
 
     /**
+     * Path of the yotpo messaging customers sync retry cron expression string
+     */
+    // phpcs:ignore
+    const YOTPO_MESSAGING_CUSTOMERS_SYNC_RETRY_CRON_EXPRESSION_PATH = 'crontab/yotpo_messaging_customers_sync/jobs/yotpo_cron_messaging_customers_sync_retry/schedule/cron_expr';
+    /**
      * @var ValueFactory
      */
     protected $_configValueFactory;
@@ -72,6 +77,8 @@ class CustomersScheduler extends ConfigValue
         $customersCronExpressionString = $this->getData('groups/sync_settings/groups/customers_sync/fields/frequency/value');
         try {
             $this->configureCronCustomersSync($customersCronExpressionString);
+
+            $this->configureCronCustomersSyncRetry($customersCronExpressionString);
         } catch (\Exception $exception) {
             throw new AlreadyExistsException(__('We can\'t save the cron expression.'));
         }
@@ -79,7 +86,7 @@ class CustomersScheduler extends ConfigValue
     }
 
     /**
-     * @param $customersCronExpressionString
+     * @param string $customersCronExpressionString
      * @return void
      */
     private function configureCronCustomersSync($customersCronExpressionString)
@@ -92,6 +99,23 @@ class CustomersScheduler extends ConfigValue
             $customersCronExpressionString
         )->setPath(
             self::YOTPO_MESSAGING_CUSTOMERS_SYNC_CRON_EXPRESSION_PATH
+        )->save();
+    }
+
+    /**
+     * @param string $customersCronExpressionString
+     * @return void
+     */
+    private function configureCronCustomersSyncRetry($customersCronExpressionString)
+    {
+        /** @phpstan-ignore-next-line */
+        $this->_configValueFactory->create()->load(
+            self::YOTPO_MESSAGING_CUSTOMERS_SYNC_RETRY_CRON_EXPRESSION_PATH,
+            'path'
+        )->setValue(
+            $customersCronExpressionString
+        )->setPath(
+            self::YOTPO_MESSAGING_CUSTOMERS_SYNC_RETRY_CRON_EXPRESSION_PATH
         )->save();
     }
 }

--- a/Model/Config/Backend/Sync/CustomersScheduler.php
+++ b/Model/Config/Backend/Sync/CustomersScheduler.php
@@ -69,14 +69,14 @@ class CustomersScheduler extends ConfigValue
      */
     public function afterSave()
     {
-        $cronExprString = $this->getData('groups/sync_settings/groups/customers_sync/fields/frequency/value');
+        $customersCronExpressionString = $this->getData('groups/sync_settings/groups/customers_sync/fields/frequency/value');
         try {
             /** @phpstan-ignore-next-line */
             $this->_configValueFactory->create()->load(
                 self::YOTPO_MESSAGING_CUSTOMERS_SYNC_CRON_EXPRESSION_PATH,
                 'path'
             )->setValue(
-                $cronExprString
+                $customersCronExpressionString
             )->setPath(
                 self::YOTPO_MESSAGING_CUSTOMERS_SYNC_CRON_EXPRESSION_PATH
             )->save();

--- a/Model/Config/Backend/Sync/CustomersScheduler.php
+++ b/Model/Config/Backend/Sync/CustomersScheduler.php
@@ -38,7 +38,7 @@ class CustomersScheduler extends ConfigValue
      * CustomersScheduler constructor.
      * @param Context $context
      * @param Registry $registry
-     * @param ScopeConfigInterface $config
+     * @param ScopeConfigInterface $scopeConfig
      * @param TypeListInterface $cacheTypeList
      * @param ValueFactory $configValueFactory
      * @param AbstractResource|null $resource
@@ -49,7 +49,7 @@ class CustomersScheduler extends ConfigValue
     public function __construct(
         Context $context,
         Registry $registry,
-        ScopeConfigInterface $config,
+        ScopeConfigInterface $scopeConfig,
         TypeListInterface $cacheTypeList,
         ValueFactory $configValueFactory,
         AbstractResource $resource = null,
@@ -58,7 +58,7 @@ class CustomersScheduler extends ConfigValue
     ) {
         $this->_runModelPath = '';
         $this->_configValueFactory = $configValueFactory;
-        parent::__construct($context, $registry, $config, $cacheTypeList, $resource, $resourceCollection, $data);
+        parent::__construct($context, $registry, $scopeConfig, $cacheTypeList, $resource, $resourceCollection, $data);
     }
 
     /**

--- a/Model/Config/Backend/Sync/CustomersScheduler.php
+++ b/Model/Config/Backend/Sync/CustomersScheduler.php
@@ -80,7 +80,7 @@ class CustomersScheduler extends ConfigValue
             )->setPath(
                 self::CRON_STRING_PATH
             )->save();
-        } catch (\Exception $e) {
+        } catch (\Exception $exception) {
             throw new AlreadyExistsException(__('We can\'t save the cron expression.'));
         }
         return parent::afterSave();

--- a/Model/Config/Backend/Sync/CustomersScheduler.php
+++ b/Model/Config/Backend/Sync/CustomersScheduler.php
@@ -19,10 +19,10 @@ use Magento\Framework\Registry;
 class CustomersScheduler extends ConfigValue
 {
     /**
-     * Path of the cron string
+     * Path of the yotpo messaging customers sync cron expression string
      */
     // phpcs:ignore
-    const CRON_STRING_PATH = 'crontab/yotpo_messaging_customers_sync/jobs/yotpo_cron_messaging_customers_sync/schedule/cron_expr';
+    const YOTPO_MESSAGING_CUSTOMERS_SYNC_CRON_EXPRESSION_PATH = 'crontab/yotpo_messaging_customers_sync/jobs/yotpo_cron_messaging_customers_sync/schedule/cron_expr';
 
     /**
      * @var ValueFactory
@@ -73,12 +73,12 @@ class CustomersScheduler extends ConfigValue
         try {
             /** @phpstan-ignore-next-line */
             $this->_configValueFactory->create()->load(
-                self::CRON_STRING_PATH,
+                self::YOTPO_MESSAGING_CUSTOMERS_SYNC_CRON_EXPRESSION_PATH,
                 'path'
             )->setValue(
                 $cronExprString
             )->setPath(
-                self::CRON_STRING_PATH
+                self::YOTPO_MESSAGING_CUSTOMERS_SYNC_CRON_EXPRESSION_PATH
             )->save();
         } catch (\Exception $exception) {
             throw new AlreadyExistsException(__('We can\'t save the cron expression.'));

--- a/Model/Sync/Customers/Cron/CustomersSync.php
+++ b/Model/Sync/Customers/Cron/CustomersSync.php
@@ -33,7 +33,7 @@ class CustomersSync
      * @throws NoSuchEntityException
      * @throws LocalizedException
      */
-    public function processCustomers()
+    public function execute()
     {
         $this->customersProcessor->process();
     }

--- a/Model/Sync/Customers/Cron/CustomersSyncRetry.php
+++ b/Model/Sync/Customers/Cron/CustomersSyncRetry.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Yotpo\SmsBump\Model\Sync\Customers\Cron;
+use Yotpo\SmsBump\Model\Sync\Customers\Services\CustomersService;
 
 /**
  * Class CustomersSyncRetry - Processes customers which failed to be synced - using cron job
@@ -8,9 +9,19 @@ namespace Yotpo\SmsBump\Model\Sync\Customers\Cron;
 class CustomersSyncRetry
 {
     /**
-     * CustomersSyncRetry constructor.
+     * @var CustomersService
      */
-    public function __construct() { }
+    protected $customersService;
+
+    /**
+     * CustomersSyncRetry constructor.
+     * @param CustomersService $customersService
+     */
+    public function __construct(
+        CustomersService $customersService
+    ) {
+        $this->customersService = $customersService;
+    }
 
     /**
      * Process customers sync
@@ -19,6 +30,6 @@ class CustomersSyncRetry
      */
     public function execute()
     {
-
+        $this->customersService->processCustomersSyncTableResync();
     }
 }

--- a/Model/Sync/Customers/Cron/CustomersSyncRetry.php
+++ b/Model/Sync/Customers/Cron/CustomersSyncRetry.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Yotpo\SmsBump\Model\Sync\Customers\Cron;
+
+/**
+ * Class CustomersSyncRetry - Processes customers which failed to be synced - using cron job
+ */
+class CustomersSyncRetry
+{
+    /**
+     * CustomersSyncRetry constructor.
+     */
+    public function __construct() { }
+
+    /**
+     * Process customers sync
+     *
+     * @return void
+     */
+    public function execute()
+    {
+
+    }
+}

--- a/Model/Sync/Customers/Main.php
+++ b/Model/Sync/Customers/Main.php
@@ -5,15 +5,22 @@ namespace Yotpo\SmsBump\Model\Sync\Customers;
 use Magento\Framework\DataObject;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Store\Model\App\Emulation as AppEmulation;
+use Magento\Customer\Model\ResourceModel\Customer\CollectionFactory as CustomerFactory;
 use Magento\Framework\App\ResourceConnection;
 use Yotpo\SmsBump\Model\Config;
 use Yotpo\Core\Model\Sync\Customers\Processor as CoreCustomersProcessor;
+use Yotpo\SmsBump\Model\Sync\Customers\Logger as YotpoCustomersLogger;
 
 /**
  * Class Main - Manage Customers sync
  */
 class Main extends CoreCustomersProcessor
 {
+    /**
+     * Customers sync limit config key
+     */
+    const CUSTOMERS_SYNC_LIMIT_CONFIG_KEY = 'customers_sync_limit';
+
     /**
      * @var Config
      */
@@ -25,9 +32,24 @@ class Main extends CoreCustomersProcessor
     protected $data;
 
     /**
+     * @var CustomerFactory
+     */
+    protected $customerFactory;
+
+    /**
      * @var ResourceConnection
      */
     protected $resourceConnection;
+
+    /**
+     * @var YotpoCustomersLogger
+     */
+    protected $yotpoCustomersLogger;
+
+    /**
+     * Customer sync batch size retrieved from configuration
+     */
+    protected $customersSyncBatchSize;
 
     /**
      * Main constructor.
@@ -35,69 +57,88 @@ class Main extends CoreCustomersProcessor
      * @param ResourceConnection $resourceConnection
      * @param Config $config
      * @param Data $data
+     * @param CustomerFactory $customerFactory
+     * @param YotpoCustomersLogger $yotpoCustomersLogger
      */
     public function __construct(
         AppEmulation $appEmulation,
         ResourceConnection $resourceConnection,
         Config $config,
-        Data $data
+        Data $data,
+        CustomerFactory $customerFactory,
+        YotpoCustomersLogger $yotpoCustomersLogger
     ) {
-        $this->config =  $config;
-        $this->data   =  $data;
+        $this->config = $config;
+        $this->data = $data;
+        $this->customerFactory = $customerFactory;
         $this->resourceConnection = $resourceConnection;
+        $this->yotpoCustomersLogger = $yotpoCustomersLogger;
+        $this->customersSyncBatchSize = $this->config->getConfig($this::CUSTOMERS_SYNC_LIMIT_CONFIG_KEY);
         parent::__construct($appEmulation, $resourceConnection);
     }
 
     /**
-     * Get synced customers
-     *
-     * @param array<mixed> $magentoCustomers
-     * @return array<mixed>
-     * @throws NoSuchEntityException
+     * @param array $retryCustomersIds
+     * @param int $storeId
+     * @return mixed
      */
-    public function getYotpoSyncedCustomers($magentoCustomers)
+    public function createCustomersCollectionQuery($retryCustomersIds, $storeId)
     {
-        $return     =   [];
-        $connection =   $this->resourceConnection->getConnection();
-        $storeId    =   $this->config->getStoreId();
-        $table      =   $this->resourceConnection->getTableName('yotpo_customers_sync');
-        $customers  =   $connection->select()
-            ->from($table)
-            ->where('customer_id IN(?) ', array_keys($magentoCustomers))
-            ->where('store_id=(?)', $storeId);
-        $customers =   $connection->fetchAssoc($customers, []);
-        foreach ($customers as $cust) {
-            $return[$cust['customer_id']]  =   $cust;
+        $customersCollectionQuery = $this->customerFactory->create();
+        $customersCollectionQuery->addAttributeToSelect('*');
+        if ($retryCustomersIds) {
+            $customersCollectionQuery
+                ->addFieldToFilter('entity_id', ['in' => $retryCustomersIds])
+                ->getSelect();
+            return $customersCollectionQuery;
         }
-        return $return;
+
+        $syncedToYotpoCustomerAttributeName = $this->config::SYNCED_TO_YOTPO_CUSTOMER_ATTRIBUTE_NAME;
+        $customersCollectionQuery
+            ->addFieldToFilter('store_id', $storeId)
+            ->addAttributeToFilter([
+                [ 'attribute' => $syncedToYotpoCustomerAttributeName, 'null' => true ],
+                [ 'attribute' => $syncedToYotpoCustomerAttributeName, 'eq' => 0 ]
+            ])
+            ->getSelect()
+            ->limit($this->customersSyncBatchSize);
+
+        return $customersCollectionQuery;
     }
 
     /**
-     * Prepares custom table data
-     *
-     * @param array<mixed>|DataObject $customerSyncToYotpoResponse
-     * @param int|null $magentoCustomerId
-     * @return array<mixed>
+     * Prepares Customer sync table data
+     * @param DataObject $customerSyncToYotpoResponse
+     * @param int $magentoCustomerId
+     * @param string $storeId
+     * @return array
      */
-    public function createCustomerSyncData($customerSyncToYotpoResponse, $magentoCustomerId)
+    public function createCustomerSyncData($customerSyncToYotpoResponse, $magentoCustomerId, $storeId)
     {
+        $currentTime = date('Y-m-d H:i:s');
+        $statusCode = $customerSyncToYotpoResponse->getData('status');
+        $shouldRetry = $this->config->isNetworkRetriableResponse($statusCode);
         $customerSyncData = [
             /** @phpstan-ignore-next-line */
-            'response_code' =>  $customerSyncToYotpoResponse->getData('status'),
-            'customer_id'   =>  $magentoCustomerId
+            'customer_id' => $magentoCustomerId,
+            'response_code' => $statusCode,
+            'should_retry' => $shouldRetry,
+            'store_id' => $storeId,
+            'synced_to_yotpo' => $currentTime
         ];
+
         return $customerSyncData;
     }
 
     /**
      * @param string $customerId
      * @param int $customerStoreId
-     * @param int $syncStatus
+     * @param int $shouldRetry
      * @param boolean $shouldUpdateAllStores
      * @return void
      * @throws NoSuchEntityException|LocalizedException
      */
-    public function resetCustomerSyncStatus($customerId, $customerStoreId, $syncStatus, $shouldUpdateAllStores = false)
+    public function resetCustomerSyncStatus($customerId, $customerStoreId, $shouldRetry = 1, $shouldUpdateAllStores = false)
     {
         $customersSyncData = [];
         $storeIds = [];
@@ -114,7 +155,7 @@ class Main extends CoreCustomersProcessor
             $customersSyncData[] = [
                 'customer_id' => $customerId,
                 'store_id' => $storeId,
-                'sync_status' => $syncStatus,
+                'should_retry' => $shouldRetry,
                 'response_code' => '200'
             ];
         }
@@ -125,11 +166,29 @@ class Main extends CoreCustomersProcessor
     /**
      * Inserts or updates custom table data
      *
-     * @param array<mixed> $customerSyncData
+     * @param array $customerSyncData
      * @return void
      */
     public function insertOrUpdateCustomerSyncData($customerSyncData)
     {
-        $this->insertOnDuplicate('yotpo_customers_sync', [$customerSyncData]);
+        $this->insertOnDuplicate($this->config::YOTPO_CUSTOMERS_SYNC_TABLE_NAME, [$customerSyncData]);
+    }
+
+    /**
+     * @param int $customerId
+     * @param string $attributeCode
+     * @param boolean $isSynced
+     * @return void
+     * @throws NoSuchEntityException
+     */
+    public function insertOrUpdateCustomerAttribute($customerId, $attributeCode, $isSynced = true)
+    {
+        $customerEntityIntData = [
+            'attribute_id' => $attributeCode,
+            'entity_id' => $customerId,
+            'value' => $isSynced
+        ];
+
+        $this->insertOnDuplicate($this->config::CUSTOMER_ENTITY_INT_TABLE_NAME, [$customerEntityIntData]);
     }
 }

--- a/Model/Sync/Customers/Main.php
+++ b/Model/Sync/Customers/Main.php
@@ -155,6 +155,29 @@ class Main extends CoreCustomersProcessor
     }
 
     /**
+     * Creates failed customer sync table data
+     * @param int $magentoCustomerId
+     * @param string $storeId
+     * @return array
+     */
+    public function createServerErrorCustomerSyncData($magentoCustomerId, $storeId)
+    {
+        $currentTime = date('Y-m-d H:i:s');
+        $statusCode = '500';
+        $shouldRetry = false;
+        $customerSyncData = [
+            /** @phpstan-ignore-next-line */
+            'customer_id' => $magentoCustomerId,
+            'response_code' => $statusCode,
+            'should_retry' => $shouldRetry,
+            'store_id' => $storeId,
+            'synced_to_yotpo' => $currentTime
+        ];
+
+        return $customerSyncData;
+    }
+
+    /**
      * Inserts or updates custom table data
      *
      * @param array $customerSyncData

--- a/Model/Sync/Customers/Main.php
+++ b/Model/Sync/Customers/Main.php
@@ -155,39 +155,6 @@ class Main extends CoreCustomersProcessor
     }
 
     /**
-     * @param string $customerId
-     * @param int $customerStoreId
-     * @param int $shouldRetry
-     * @param boolean $shouldUpdateAllStores
-     * @return void
-     * @throws NoSuchEntityException|LocalizedException
-     */
-    public function resetCustomerSyncStatus($customerId, $customerStoreId, $shouldRetry = 1, $shouldUpdateAllStores = false)
-    {
-        $customersSyncData = [];
-        $storeIds = [];
-        if (!$shouldUpdateAllStores && !$this->config->isCustomerAccountShared()) {
-            $storeIds[] = $customerStoreId;
-        } else {
-            /** @phpstan-ignore-next-line */
-            foreach ($this->config->getAllStoreIds(false) as $storeId) {
-                $storeIds[] = $storeId;
-            }
-        }
-
-        foreach ($storeIds as $storeId) {
-            $customersSyncData[] = [
-                'customer_id' => $customerId,
-                'store_id' => $storeId,
-                'should_retry' => $shouldRetry,
-                'response_code' => '200'
-            ];
-        }
-
-        $this->insertOrUpdateCustomerSyncData($customersSyncData);
-    }
-
-    /**
      * Inserts or updates custom table data
      *
      * @param array $customerSyncData

--- a/Model/Sync/Customers/Main.php
+++ b/Model/Sync/Customers/Main.php
@@ -90,6 +90,39 @@ class Main extends CoreCustomersProcessor
     }
 
     /**
+     * @param string $customerId
+     * @param int $customerStoreId
+     * @param int $syncStatus
+     * @param boolean $shouldUpdateAllStores
+     * @return void
+     * @throws NoSuchEntityException|LocalizedException
+     */
+    public function resetCustomerSyncStatus($customerId, $customerStoreId, $syncStatus, $shouldUpdateAllStores = false)
+    {
+        $customersSyncData = [];
+        $storeIds = [];
+        if (!$shouldUpdateAllStores && !$this->config->isCustomerAccountShared()) {
+            $storeIds[] = $customerStoreId;
+        } else {
+            /** @phpstan-ignore-next-line */
+            foreach ($this->config->getAllStoreIds(false) as $storeId) {
+                $storeIds[] = $storeId;
+            }
+        }
+
+        foreach ($storeIds as $storeId) {
+            $customersSyncData[] = [
+                'customer_id' => $customerId,
+                'store_id' => $storeId,
+                'sync_status' => $syncStatus,
+                'response_code' => '200'
+            ];
+        }
+
+        $this->insertOrUpdateCustomerSyncData($customersSyncData);
+    }
+
+    /**
      * Inserts or updates custom table data
      *
      * @param array<mixed> $customerSyncData

--- a/Model/Sync/Customers/Main.php
+++ b/Model/Sync/Customers/Main.php
@@ -107,6 +107,30 @@ class Main extends CoreCustomersProcessor
     }
 
     /**
+     * @return array<string>
+     */
+    public function getCustomersIdsForCustomersThatShouldBeRetriedForSync()
+    {
+        $storeId = $this->config->getStoreId();
+        $connection = $this->resourceConnection->getConnection();
+        $shouldRetryCustomersQuery = $connection->select()->from(
+            [$this->resourceConnection->getTableName($this->config::YOTPO_CUSTOMERS_SYNC_TABLE_NAME)],
+            ['customer_id']
+        )->where(
+            'store_id = ?',
+            $storeId
+        )->where(
+            'should_retry = ?',
+            1
+        )->limit(
+            $this->customersSyncBatchSize
+        );
+
+        $customersIdsMapForSync = $connection->fetchAssoc($shouldRetryCustomersQuery, 'customer_id');
+        return array_keys($customersIdsMapForSync);
+    }
+
+    /**
      * Prepares Customer sync table data
      * @param DataObject $customerSyncToYotpoResponse
      * @param int $magentoCustomerId

--- a/Model/Sync/Customers/Processor.php
+++ b/Model/Sync/Customers/Processor.php
@@ -370,7 +370,8 @@ class Processor extends Main
 
         $url = $this->config->getEndpoint('customers');
         $customerDataForSync['entityLog'] = 'customers';
-        $response = $this->yotpoSyncMain->sync('PATCH', $url, $customerDataForSync);
+        $method = $this->config::PATCH_METHOD_STRING;
+        $response = $this->yotpoSyncMain->sync($method, $url, $customerDataForSync);
         if ($response->getData('is_success')) {
             $this->yotpoCustomersLogger->info(
                 __(

--- a/Model/Sync/Customers/Processor.php
+++ b/Model/Sync/Customers/Processor.php
@@ -101,7 +101,7 @@ class Processor extends Main
      * @throws LocalizedException
      * @throws NoSuchEntityException
      */
-    public function process($retryCustomers = [], $storeIds = [])
+    public function process($retryCustomersIds = [], $storeIds = [])
     {
         if (!$storeIds) {
             $storeIds = $this->config->getAllStoreIds(false);
@@ -137,7 +137,7 @@ class Processor extends Main
                     $this->config->getStoreName($storeId)
                 )
             );
-            $retryCustomerIds = $retryCustomers[$storeId] ?? $retryCustomers;
+            $retryCustomerIds = $retryCustomersIds[$storeId] ?? $retryCustomersIds;
             $this->processEntities($retryCustomerIds);
             $this->stopEnvironmentEmulation();
         }
@@ -241,7 +241,7 @@ class Processor extends Main
      * @throws LocalizedException
      * @throws NoSuchEntityException
      */
-    public function processEntities($retryCustomerIds = [])
+    public function processEntities($retryCustomersIds = [])
     {
         $storeId = $this->config->getStoreId();
         $websiteId = $this->storeManager->getStore($storeId)->getWebsiteId();
@@ -252,7 +252,7 @@ class Processor extends Main
         $customerCollectionWithYotpoDataQuery =
             $this->createCustomerCollectionWithYotpoSyncDataQuery(
                 $storeId,
-                $retryCustomerIds,
+                $retryCustomersIds,
                 $isCustomerAccountShared,
                 $websiteId,
                 $batchSize
@@ -454,7 +454,7 @@ class Processor extends Main
 
     /**
      * @param int $storeId
-     * @param array<mixed> $retryCustomerIds
+     * @param array<mixed> $retryCustomersIds
      * @param bool $customerAccountShared
      * @param int $websiteId
      * @param int $batchSize
@@ -462,7 +462,7 @@ class Processor extends Main
      */
     private function createCustomerCollectionWithYotpoSyncDataQuery(
         $storeId,
-        $retryCustomerIds,
+        $retryCustomersIds,
         $customerAccountShared,
         $websiteId,
         $batchSize
@@ -478,12 +478,12 @@ class Processor extends Main
                 'response_code'
             ]
         );
-        if (!$retryCustomerIds) {
+        if (!$retryCustomersIds) {
             $customerCollection->getSelect()
                 ->where('yotpo_customers_sync.sync_status is null OR  yotpo_customers_sync.sync_status = ?', 0);
         } else {
             $customerCollection->getSelect()
-                ->where('e.entity_id in (?)', $retryCustomerIds);
+                ->where('e.entity_id in (?)', $retryCustomersIds);
         }
         if (!$customerAccountShared) {
             $customerCollection->getSelect()

--- a/Model/Sync/Customers/Processor.php
+++ b/Model/Sync/Customers/Processor.php
@@ -120,8 +120,7 @@ class Processor extends Main
                         'Customer sync is disabled for Magento Store ID: %1, Name: %2',
                         $storeId,
                         $this->config->getStoreName($storeId)
-                    ),
-                    []
+                    )
                 );
                 if ($this->isCommandLineSync) {
                     // phpcs:ignore
@@ -136,8 +135,7 @@ class Processor extends Main
                     'Process customers for Magento Store ID: %1, Name: %2',
                     $storeId,
                     $this->config->getStoreName($storeId)
-                ),
-                []
+                )
             );
             $retryCustomerIds = $retryCustomers[$storeId] ?? $retryCustomers;
             $this->processEntities($retryCustomerIds);

--- a/Model/Sync/Customers/Processor.php
+++ b/Model/Sync/Customers/Processor.php
@@ -201,8 +201,8 @@ class Processor extends Main
             $storesIdsEligibleForSync = $this->getEligibleStoresForSync();
             $syncedToYotpoCustomerAttributeCode = $this->yotpoCoreSyncData->getAttributeId($this->config::SYNCED_TO_YOTPO_CUSTOMER_ATTRIBUTE_NAME);
             foreach ($customersCollection as $customer) {
+                $customerId = $customer->getId();
                 try {
-                    $customerId = $customer->getId();
                     if ($isCustomerAccountShared) {
                         $this->syncSharedStoresCustomer($customer, $storesIdsEligibleForSync);
                     } else {
@@ -216,9 +216,10 @@ class Processor extends Main
                 } catch (Exception $exception) {
                     $this->yotpoCustomersLogger->info(
                         __(
-                            'Failed to sync customer to Yotpo - Magento Store ID: %1, Magento Store Name: %2, Reason: %3',
+                            'Failed to sync customer to Yotpo - Magento Store ID: %1, Magento Store Name: %2, Customer ID: %3 Exception Message: %4',
                             $storeId,
                             $this->config->getStoreName($storeId),
+                            $customerId,
                             $exception->getMessage()
                         )
                     );

--- a/Model/Sync/Customers/Processor.php
+++ b/Model/Sync/Customers/Processor.php
@@ -12,7 +12,7 @@ use Magento\Customer\Model\ResourceModel\Customer\CollectionFactory as CustomerF
 use Yotpo\SmsBump\Model\Sync\Main as SmsBumpSyncMain;
 use Magento\Store\Model\App\Emulation as AppEmulation;
 use Magento\Framework\App\ResourceConnection;
-use Yotpo\SmsBump\Model\Sync\Customers\Logger as YotpoSmsBumpLogger;
+use Yotpo\SmsBump\Model\Sync\Customers\Logger as YotpoCustomersLogger;
 use Magento\Customer\Model\Customer;
 use Yotpo\SmsBump\Api\YotpoCustomersSyncRepositoryInterface;
 
@@ -37,9 +37,9 @@ class Processor extends Main
     protected $data;
 
     /**
-     * @var Logger
+     * @var YotpoCustomersLogger
      */
-    protected $yotpoSmsBumpLogger;
+    protected $yotpoCustomersLogger;
 
     /**
      * @var array <mixed>
@@ -69,7 +69,7 @@ class Processor extends Main
      * @param SmsBumpSyncMain $yotpoSyncMain
      * @param CustomerFactory $customerFactory
      * @param CustomersData $data
-     * @param Logger $yotpoSmsBumpLogger
+     * @param YotpoCustomersLogger $yotpoCustomersLogger
      * @param StoreManagerInterface $storeManager
      * @param YotpoCustomersSyncRepositoryInterface $yotpoCustomersSyncRepositoryInterface
      */
@@ -80,13 +80,13 @@ class Processor extends Main
         SmsBumpSyncMain $yotpoSyncMain,
         CustomerFactory $customerFactory,
         CustomersData $data,
-        YotpoSmsBumpLogger $yotpoSmsBumpLogger,
+        YotpoCustomersLogger $yotpoCustomersLogger,
         StoreManagerInterface $storeManager,
         YotpoCustomersSyncRepositoryInterface $yotpoCustomersSyncRepositoryInterface
     ) {
         $this->yotpoSyncMain = $yotpoSyncMain;
         $this->customerFactory = $customerFactory;
-        $this->yotpoSmsBumpLogger = $yotpoSmsBumpLogger;
+        $this->yotpoCustomersLogger = $yotpoCustomersLogger;
         $this->storeManager= $storeManager;
         $this->yotpoCustomersSyncRepositoryInterface = $yotpoCustomersSyncRepositoryInterface;
         parent::__construct($appEmulation, $resourceConnection, $yotpoSmsConfig, $data);
@@ -115,7 +115,7 @@ class Processor extends Main
             }
             $this->emulateFrontendArea($storeId);
             if (!$this->config->isCustomerSyncActive()) {
-                $this->yotpoSmsBumpLogger->info(
+                $this->yotpoCustomersLogger->info(
                     __(
                         'Customer sync is disabled for Magento Store ID: %1, Name: %2',
                         $storeId,
@@ -130,7 +130,7 @@ class Processor extends Main
                 $this->stopEnvironmentEmulation();
                 continue;
             }
-            $this->yotpoSmsBumpLogger->info(
+            $this->yotpoCustomersLogger->info(
                 __(
                     'Process customers for Magento Store ID: %1, Name: %2',
                     $storeId,
@@ -172,7 +172,7 @@ class Processor extends Main
                 continue;
             }
 
-            $this->yotpoSmsBumpLogger->info(
+            $this->yotpoCustomersLogger->info(
                 __(
                     'Starting syncing Customer to Yotpo - Magento Store ID: %1, Name: %2, Customer ID: %3',
                     $storeId,
@@ -208,7 +208,7 @@ class Processor extends Main
                 $this->updateLastSyncDate($currentTime);
                 $customerSyncData = $this->updateCustomerSyncData($customerSyncData, $currentTime);
                 $this->insertOrUpdateCustomerSyncData($customerSyncData);
-                $this->yotpoSmsBumpLogger->info(
+                $this->yotpoCustomersLogger->info(
                     __(
                         'Finished syncing Customer to Yotpo - Magento Store ID: %1, Name: %2, CustomerID: %3',
                         $storeId,
@@ -218,7 +218,7 @@ class Processor extends Main
                 );
             }
         } catch (NoSuchEntityException | LocalizedException $e) {
-            $this->yotpoSmsBumpLogger->info(
+            $this->yotpoCustomersLogger->info(
                 __(
                     'Failed to sync Customer to Yotpo -
                     Magento Store ID: %1,
@@ -260,7 +260,7 @@ class Processor extends Main
         $customerCollectionWithYotpoSyncData = $customerCollectionWithYotpoDataQuery->getItems();
 
         if (!count($customerCollectionWithYotpoSyncData)) {
-            $this->yotpoSmsBumpLogger->info(
+            $this->yotpoCustomersLogger->info(
                 __(
                     'No customers that should be synced found - Magento Store ID: %1, Name: %2',
                     $storeId,
@@ -268,7 +268,7 @@ class Processor extends Main
                 )
             );
         } else {
-            $this->yotpoSmsBumpLogger->info(
+            $this->yotpoCustomersLogger->info(
                 __(
                     'Starting Customers sync to Yotpo Cron job - Magento Store ID: %1, Name: %2',
                     $storeId,
@@ -284,7 +284,7 @@ class Processor extends Main
                 $responseCode = $customerWithYotpoSyncData['response_code'];
 
                 if (!$this->config->canResync($responseCode, [], $this->isCommandLineSync)) {
-                    $this->yotpoSmsBumpLogger->info('Customer sync cannot be done for customerId: '
+                    $this->yotpoCustomersLogger->info('Customer sync cannot be done for customerId: '
                         . $customerId . ', due to response code: ' . $responseCode, []);
                     continue;
                 }
@@ -301,7 +301,7 @@ class Processor extends Main
                 }
             }
 
-            $this->yotpoSmsBumpLogger->info(
+            $this->yotpoCustomersLogger->info(
                 __(
                     'Finished Customers sync to Yotpo Cron job - Magento Store ID: %1, Name: %2',
                     $storeId,
@@ -326,7 +326,7 @@ class Processor extends Main
     public function syncCustomer($customer, $isRealTimeSync = false, $customerAddress = null)
     {
         $customerId = $customer->getId();
-        $this->yotpoSmsBumpLogger->info(
+        $this->yotpoCustomersLogger->info(
             __(
                 'Starting syncing Customer to Yotpo - Customer ID: %1',
                 $customerId
@@ -341,7 +341,7 @@ class Processor extends Main
         }
 
         if (!$customerData) {
-            $this->yotpoSmsBumpLogger->info(
+            $this->yotpoCustomersLogger->info(
                 __(
                     'Stopped syncing Customer to Yotpo - no new data to sync - Customer ID: %1',
                     $customerId
@@ -354,7 +354,7 @@ class Processor extends Main
         $customerData['entityLog'] = 'customers';
         $response = $this->yotpoSyncMain->sync('PATCH', $url, $customerData);
         if ($response->getData('is_success')) {
-            $this->yotpoSmsBumpLogger->info(
+            $this->yotpoCustomersLogger->info(
                 __(
                     'Finished syncing Customer to Yotpo successfully - Customer ID: %1',
                     $customerId

--- a/Model/Sync/Customers/Processor.php
+++ b/Model/Sync/Customers/Processor.php
@@ -234,39 +234,6 @@ class Processor extends Main
     }
 
     /**
-     * @param string $customerId
-     * @param int $customerStoreId
-     * @param int $syncStatus
-     * @param boolean $shouldUpdateAllStores
-     * @return void
-     * @throws NoSuchEntityException|LocalizedException
-     */
-    public function resetCustomerSyncStatus($customerId, $customerStoreId, $syncStatus, $shouldUpdateAllStores = false)
-    {
-        $customersSyncData = [];
-        $storeIds = [];
-        if (!$shouldUpdateAllStores && !$this->config->isCustomerAccountShared()) {
-            $storeIds[] = $customerStoreId;
-        } else {
-            /** @phpstan-ignore-next-line */
-            foreach ($this->config->getAllStoreIds(false) as $storeId) {
-                $storeIds[] = $storeId;
-            }
-        }
-
-        foreach ($storeIds as $storeId) {
-            $customersSyncData[] = [
-                'customer_id' => $customerId,
-                'store_id' => $storeId,
-                'sync_status' => $syncStatus,
-                'response_code' => '200'
-            ];
-        }
-
-        $this->insertOrUpdateCustomerSyncData($customersSyncData);
-    }
-
-    /**
      * @throws LocalizedException
      * @throws NoSuchEntityException
      * @return void

--- a/Model/Sync/Customers/Processor.php
+++ b/Model/Sync/Customers/Processor.php
@@ -371,7 +371,8 @@ class Processor extends Main
         $url = $this->config->getEndpoint('customers');
         $customerDataForSync['entityLog'] = 'customers';
         $method = $this->config::PATCH_METHOD_STRING;
-        $response = $this->yotpoSyncMain->sync($method, $url, $customerDataForSync);
+        $baseUriKey = 'api';
+        $response = $this->yotpoSyncMain->sync($method, $url, $customerDataForSync, $baseUriKey, true);
         if ($response->getData('is_success')) {
             $this->yotpoCustomersLogger->info(
                 __(

--- a/Model/Sync/Customers/Processor.php
+++ b/Model/Sync/Customers/Processor.php
@@ -214,6 +214,9 @@ class Processor extends Main
                         $this->insertOrUpdateCustomerAttribute($customerId, $syncedToYotpoCustomerAttributeCode);
                     }
                 } catch (Exception $exception) {
+                    $this->insertOrUpdateCustomerAttribute($customerId, $syncedToYotpoCustomerAttributeCode);
+                    $customerSyncData = $this->createServerErrorCustomerSyncData($customerId, $storeId);
+                    $this->insertOrUpdateCustomerSyncData($customerSyncData);
                     $this->yotpoCustomersLogger->info(
                         __(
                             'Failed to sync customer to Yotpo - Magento Store ID: %1, Magento Store Name: %2, Customer ID: %3 Exception Message: %4',
@@ -272,8 +275,7 @@ class Processor extends Main
                 $this->syncCustomer($customer, $storeId, true, $customerAddress);
             }
 
-            $syncedToYotpoCustomerAttributeCode = $this->yotpoCoreSyncData->getAttributeId($this->config::SYNCED_TO_YOTPO_CUSTOMER_ATTRIBUTE_NAME);
-            $this->insertOrUpdateCustomerAttribute($customerId, $syncedToYotpoCustomerAttributeCode);
+            $this->updateSyncedToYotpoCustomerAttributeAsSynced($customerId);
 
             $this->yotpoCustomersLogger->info(
                 __(
@@ -284,6 +286,9 @@ class Processor extends Main
                 )
             );
         } catch (Exception $exception) {
+            $this->updateSyncedToYotpoCustomerAttributeAsSynced($customerId);
+            $customerSyncData = $this->createServerErrorCustomerSyncData($customerId, $storeId);
+            $this->insertOrUpdateCustomerSyncData($customerSyncData);
             $this->yotpoCustomersLogger->info(
                 __(
                     'Failed to sync Customer to Yotpo - Magento Store ID: %1, Magento Store Name: %2, Customer ID: %3, Exception Message: %4',
@@ -451,5 +456,14 @@ class Processor extends Main
     private function updateLastSyncDate($currentTime)
     {
         $this->config->saveConfig('customers_last_sync_time', $currentTime);
+    }
+
+    /**
+     * @param string $customerId
+     */
+    private function updateSyncedToYotpoCustomerAttributeAsSynced($customerId)
+    {
+        $syncedToYotpoCustomerAttributeCode = $this->yotpoCoreSyncData->getAttributeId($this->config::SYNCED_TO_YOTPO_CUSTOMER_ATTRIBUTE_NAME);
+        $this->insertOrUpdateCustomerAttribute($customerId, $syncedToYotpoCustomerAttributeCode);
     }
 }

--- a/Model/Sync/Customers/Processor.php
+++ b/Model/Sync/Customers/Processor.php
@@ -296,49 +296,6 @@ class Processor extends Main
     }
 
     /**
-     * Process single customer entity
-     *
-     * @param Customer $customer
-     * @param null|mixed $customerAddress
-     * @return void
-     * @throws NoSuchEntityException
-     */
-    public function processSingleEntity($customer, $customerAddress = null)
-    {
-        $customerId = $customer->getId();
-        $storeId = $this->config->getStoreId();
-        try {
-            $this->resetCustomerSyncStatus($customerId, $storeId);
-            $customerDataForSync = $this->prepareCustomerDataForSync($customer, $customerId, true, $customerAddress);
-            $customerSyncToYotpoResponse = $this->executeCustomerSyncRequest($customer, $customerDataForSync);
-            if ($customerSyncToYotpoResponse) {
-                $currentTime = date('Y-m-d H:i:s');
-                $customerSyncData = $this->createCustomerSyncData($customerSyncToYotpoResponse, $customerId, $storeId);
-                $this->updateLastSyncDate($currentTime);
-                $this->insertOrUpdateCustomerSyncData($customerSyncData);
-                $this->yotpoCustomersLogger->info(
-                    __(
-                        'Finished syncing Customer to Yotpo - Magento Store ID: %1, Name: %2, CustomerID: %3',
-                        $storeId,
-                        $this->config->getStoreName($storeId),
-                        $customerId
-                    )
-                );
-            }
-        } catch (NoSuchEntityException | LocalizedException $e) {
-            $this->yotpoCustomersLogger->info(
-                __(
-                    'Failed to sync Customer to Yotpo - Magento Store ID: %1, Name: %2, CustomerID: %3, Exception Message: %4',
-                    $storeId,
-                    $this->config->getStoreName($storeId),
-                    $customerId,
-                    $e->getMessage()
-                )
-            );
-        }
-    }
-
-    /**
      * @throws LocalizedException
      * @throws NoSuchEntityException
      * @return void

--- a/Model/Sync/Customers/Services/CustomersAttributesService.php
+++ b/Model/Sync/Customers/Services/CustomersAttributesService.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Yotpo\SmsBump\Model\Sync\Customers\Services;
+
+use Magento\Framework\App\ResourceConnection;
+use Magento\Store\Model\App\Emulation as AppEmulation;
+use Magento\Customer\Model\Customer;
+use Yotpo\Core\Model\AbstractJobs;
+use Yotpo\SmsBump\Model\Sync\Customers\Main as CustomersMain;
+use Yotpo\Core\Model\Sync\Data\Main as YotpoCoreSyncData;
+use Yotpo\SmsBump\Model\Config;
+
+/**
+ * Class CustomersAttributesService
+ * Service for updating customers attributes in the db
+ */
+class CustomersAttributesService extends AbstractJobs
+{
+    /**
+     * Maximum reset customers sync retries attempts
+     */
+    const MAXIMUM_RESET_CUSTOMERS_SYNC_RETRIES_ATTEMPTS = 3;
+
+    /**
+     * @var Config
+     */
+    protected $config;
+
+    /**
+     * @var CustomersMain
+     */
+    protected $customersMain;
+
+    /**
+     * @var YotpoCoreSyncData
+     */
+    protected $yotpoCoreSyncData;
+
+    /**
+     * @var ResourceConnection
+     */
+    protected $resourceConnection;
+
+    /**
+     * Saves the reset customers sync attempts for retrying rest
+     */
+    protected $currentResetCustomersSyncAttempts;
+
+    /**
+     * Data constructor.
+     * @param Config $config
+     * @param CustomersMain $customersMain
+     * @param YotpoCoreSyncData $yotpoCoreSyncData
+     * @param AppEmulation $appEmulation
+     * @param ResourceConnection $resourceConnection
+     */
+    public function __construct(
+        Config $config,
+        CustomersMain $customersMain,
+        YotpoCoreSyncData $yotpoCoreSyncData,
+        AppEmulation $appEmulation,
+        ResourceConnection $resourceConnection
+    ) {
+        $this->config = $config;
+        $this->customersMain = $customersMain;
+        $this->yotpoCoreSyncData = $yotpoCoreSyncData;
+        $this->resourceConnection = $resourceConnection;
+        $this->currentResetCustomersSyncAttempts = 0;
+        parent::__construct($appEmulation, $resourceConnection);
+    }
+
+    /**
+     * @param Customer $customer
+     * @param boolean $attributeValue
+     * @return void
+     */
+    public function updateSyncedToYotpoCustomerAttribute($customer, $attributeValue)
+    {
+        $syncedToYotpoCustomerAttributeCode = $this->yotpoCoreSyncData->getAttributeId($this->config::SYNCED_TO_YOTPO_CUSTOMER_ATTRIBUTE_NAME);
+        $this->customersMain->insertOrUpdateCustomerAttribute(
+            $customer->getId(),
+            $syncedToYotpoCustomerAttributeCode,
+            $attributeValue
+        );
+    }
+}

--- a/Model/Sync/Customers/Services/CustomersService.php
+++ b/Model/Sync/Customers/Services/CustomersService.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace Yotpo\SmsBump\Model\Sync\Customers\Services;
+
+use Magento\Framework\App\ResourceConnection;
+use Magento\Store\Model\App\Emulation as AppEmulation;
+use Yotpo\Core\Model\AbstractJobs;
+use Yotpo\SmsBump\Model\Config;
+use Yotpo\SmsBump\Model\Sync\Customers\Logger as YotpoCustomersLogger;
+use Yotpo\SmsBump\Model\Sync\Customers\Processor as CustomersProcessor;
+use Yotpo\SmsBump\Model\Sync\Customers\Main as CustomersProcessorMain;
+
+class CustomersService extends AbstractJobs
+{
+    /**
+     * @var YotpoCustomersLogger
+     */
+    protected $yotpoCustomersLogger;
+
+    /**
+     * @var CustomersProcessor
+     */
+    protected $customersProcessor;
+
+    /**
+     * @var CustomersProcessorMain
+     */
+    protected $customersProcessorMain;
+
+    /**
+     * @var Config
+     */
+    protected $config;
+
+    /**
+     * Customers Service constructor.
+     * @param AppEmulation $appEmulation
+     * @param ResourceConnection $resourceConnection
+     * @param Config $config
+     * @param YotpoCustomersLogger $yotpoCustomersLogger
+     * @param CustomersProcessor $customersProcessor
+     * @param CustomersProcessorMain $customersProcessorMain
+     */
+    public function __construct(
+        AppEmulation $appEmulation,
+        ResourceConnection $resourceConnection,
+        Config $config,
+        YotpoCustomersLogger $yotpoCustomersLogger,
+        CustomersProcessor $customersProcessor,
+        CustomersProcessorMain $customersProcessorMain
+    ) {
+        $this->config = $config;
+        $this->customersProcessor = $customersProcessor;
+        $this->yotpoCustomersLogger = $yotpoCustomersLogger;
+        $this->customersProcessorMain = $customersProcessorMain;
+        parent::__construct($appEmulation, $resourceConnection);
+    }
+
+    /**
+     * Retry processing failed customers
+     * @return void
+     * @throws LocalizedException
+     * @throws NoSuchEntityException
+     */
+    public function processCustomersSyncTableResync()
+    {
+        $storeIds = $this->config->getAllStoreIds(false);
+
+        /** @phpstan-ignore-next-line */
+        foreach ($storeIds as $storeId) {
+            try {
+                $this->emulateFrontendArea($storeId);
+                if (!$this->config->isCustomerSyncActive()) {
+                    $this->yotpoCustomersLogger->info(
+                        __(
+                            'Customers retry sync is disabled for - Magento Store ID: %1, Magento Store Name: %2',
+                            $storeId,
+                            $this->config->getStoreName($storeId)
+                        )
+                    );
+                    $this->stopEnvironmentEmulation();
+                    continue;
+                }
+                $this->yotpoCustomersLogger->info(
+                    __(
+                        'Starting process Customers retry sync for - Magento Store ID: %1, Magento Store Name: %2',
+                        $storeId,
+                        $this->config->getStoreName($storeId)
+                    )
+                );
+                $customersIdsForSync = $this->customersProcessorMain->getCustomersIdsForCustomersThatShouldBeRetriedForSync();
+                $this->processFailedCustomerEntities($customersIdsForSync);
+
+                $this->yotpoCustomersLogger->info(
+                    __(
+                        'Finished process Customers retry sync for - Magento Store ID: %1, Magento Store Name: %2',
+                        $storeId,
+                        $this->config->getStoreName($storeId)
+                    )
+                );
+            } catch (Exception $exception) {
+                $this->yotpoCustomersLogger->info(
+                    __(
+                        'Failed to process Customers retry sync for - Magento Store ID: %1, Magento Store Name: %2, Reason: %3',
+                        $storeId,
+                        $this->config->getStoreName($storeId),
+                        $exception->getMessage()
+                    )
+                );
+            } finally {
+                $this->stopEnvironmentEmulation();
+            }
+        }
+    }
+
+    /**
+     * Process customer entities
+     * @param array $customersIdsForResync
+     * @return void
+     * @throws LocalizedException
+     * @throws NoSuchEntityException
+     */
+    private function processFailedCustomerEntities($customersIdsForResync)
+    {
+        $storeId = $this->config->getStoreId();
+        if (count($customersIdsForResync)) {
+            $this->customersProcessor->processEntities($customersIdsForResync, $storeId, false);
+        } else {
+            $this->yotpoCustomersLogger->info(
+                __(
+                    'No customers that should be retried found - Magento Store ID: %1, Magento Store Name: %2',
+                    $storeId,
+                    $this->config->getStoreName($storeId)
+                )
+            );
+        }
+    }
+}

--- a/Observer/Config/CronFrequency.php
+++ b/Observer/Config/CronFrequency.php
@@ -29,7 +29,7 @@ class CronFrequency extends YotpoCoreCronFrequency
      * @var array <mixed>
      */
     protected $cronFrequency = [
-        'customers_sync_frequency' => ['config_path' => '','job_code' => 'yotpo_cron_messaging_customers_sync']
+        'customers_sync_frequency' => ['config_path' => '','job_code' => 'yotpo_cron_messaging_customers_sync,yotpo_cron_messaging_customers_sync_retry']
     ];
 
     /**

--- a/Observer/Config/Customer/CustomerConfigSave.php
+++ b/Observer/Config/Customer/CustomerConfigSave.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Yotpo\SmsBump\Observer\Config\Customer;
+
+use Magento\Framework\Event\ObserverInterface;
+use Magento\Framework\Event\Observer;
+use Yotpo\SmsBump\Model\Sync\Customers\Services\CustomersAttributesService;
+use Yotpo\SmsBump\Model\Config;
+
+/**
+ * Class for Customer Config Save Observer
+ */
+class CustomerConfigSave implements ObserverInterface
+{
+    /**
+     * Customer account is shared config path
+     */
+    const CUSTOMER_ACCOUNT_SHARE_CONFIG_PATH = 'customer/account_share/scope';
+
+    /**
+     * @param Config $config
+     */
+    protected $config;
+
+    /**
+     * @param Config $config
+     * @param CustomersAttributesService $customersAttributesService
+     */
+    protected $customersAttributesService;
+
+    public function __construct(
+        Config $config,
+        CustomersAttributesService $customersAttributesService
+    ) {
+        $this->config = $config;
+        $this->customersAttributesService = $customersAttributesService;
+    }
+
+    /**
+     * @param Observer $observer
+     * @return void
+     */
+    public function execute(Observer $observer)
+    {
+        $isCustomerAccountShareSettingChangedToEnabled = $this->checkCustomerAccountShareSettingChangedToEnabled($observer);
+        if (!$isCustomerAccountShareSettingChangedToEnabled) {
+            return;
+        }
+
+        $this->customersAttributesService->resetCustomersSyncedToYotpoAttribute();
+    }
+
+    /**
+     * @param Observer $observer
+     * @return bool
+     */
+    public function checkCustomerAccountShareSettingChangedToEnabled(Observer $observer)
+    {
+        $changedConfigurationsPaths = (array) $observer->getEvent()->getChangedPaths();
+        if (in_array($this::CUSTOMER_ACCOUNT_SHARE_CONFIG_PATH, $changedConfigurationsPaths) &&
+            $this->config->isCustomerAccountShared()
+        ) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/Observer/CustomerAddressUpdate.php
+++ b/Observer/CustomerAddressUpdate.php
@@ -26,7 +26,7 @@ class CustomerAddressUpdate implements ObserverInterface
     /**
      * @var Config
      */
-    protected $yotpoSmsConfig;
+    protected $config;
 
     /**
      * @var RequestInterface
@@ -41,18 +41,18 @@ class CustomerAddressUpdate implements ObserverInterface
     /**
      * CustomerAddressUpdate constructor.
      * @param CustomersProcessor $customersProcessor
-     * @param Config $yotpoSmsConfig
+     * @param Config $config
      * @param RequestInterface $request
      * @param Session $session
      */
     public function __construct(
         CustomersProcessor $customersProcessor,
-        Config $yotpoSmsConfig,
+        Config $config,
         RequestInterface $request,
         Session $session
     ) {
         $this->customersProcessor = $customersProcessor;
-        $this->yotpoSmsConfig = $yotpoSmsConfig;
+        $this->config = $config;
         $this->request = $request;
         $this->session = $session;
     }
@@ -72,7 +72,7 @@ class CustomerAddressUpdate implements ObserverInterface
         }
         $customer = $customerAddress->getCustomer();
         $customerStoreId = $customer->getStoreId();
-        $isCustomerSyncActive = $this->yotpoSmsConfig->isCustomerSyncActive($customerStoreId);
+        $isCustomerSyncActive = $this->config->isCustomerSyncActive($customerStoreId);
 
         if (!$this->request->getParam('custSync')) {
             $this->customersProcessor->resetCustomerSyncStatus(

--- a/Observer/CustomerAddressUpdate.php
+++ b/Observer/CustomerAddressUpdate.php
@@ -79,7 +79,7 @@ class CustomerAddressUpdate implements ObserverInterface
             $this->customersProcessor->resetCustomerSyncStatus(
                 $customer->getId(),
                 $customer->getStoreId(),
-                0,
+                1,
                 true
             );
 

--- a/Observer/CustomerAddressUpdate.php
+++ b/Observer/CustomerAddressUpdate.php
@@ -71,14 +71,13 @@ class CustomerAddressUpdate implements ObserverInterface
             $this->session->unsDelegateGuestCustomer();
         }
         $customer = $customerAddress->getCustomer();
-        $isCustomerSyncActive = $this->yotpoSmsConfig->isCustomerSyncActive(
-            $customerAddress->getCustomer()->getStoreId()
-        );
+        $customerStoreId = $customer->getStoreId();
+        $isCustomerSyncActive = $this->yotpoSmsConfig->isCustomerSyncActive($customerStoreId);
 
         if (!$this->request->getParam('custSync')) {
             $this->customersProcessor->resetCustomerSyncStatus(
                 $customer->getId(),
-                $customer->getStoreId(),
+                $customerStoreId,
                 1,
                 true
             );

--- a/Observer/CustomerAddressUpdate.php
+++ b/Observer/CustomerAddressUpdate.php
@@ -7,7 +7,9 @@ use Magento\Framework\Event\Observer;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Store\Model\ScopeInterface;
+use Magento\Customer\Model\Customer;
 use Yotpo\SmsBump\Model\Sync\Customers\Processor as CustomersProcessor;
+use Yotpo\SmsBump\Model\Sync\Customers\Services\CustomersAttributesService;
 use Yotpo\SmsBump\Model\Config;
 use Magento\Framework\App\RequestInterface;
 use Magento\Checkout\Model\Session;
@@ -39,22 +41,30 @@ class CustomerAddressUpdate implements ObserverInterface
     protected $session;
 
     /**
+     * @var CustomersAttributesService
+     */
+    protected $customersAttributesService;
+
+    /**
      * CustomerAddressUpdate constructor.
      * @param CustomersProcessor $customersProcessor
      * @param Config $config
      * @param RequestInterface $request
      * @param Session $session
+     * @param CustomersAttributesService $customersAttributesService
      */
     public function __construct(
         CustomersProcessor $customersProcessor,
         Config $config,
         RequestInterface $request,
-        Session $session
+        Session $session,
+        CustomersAttributesService $customersAttributesService
     ) {
         $this->customersProcessor = $customersProcessor;
         $this->config = $config;
         $this->request = $request;
         $this->session = $session;
+        $this->customersAttributesService = $customersAttributesService;
     }
 
     /**
@@ -75,18 +85,13 @@ class CustomerAddressUpdate implements ObserverInterface
         $isCustomerSyncActive = $this->config->isCustomerSyncActive($customerStoreId);
 
         if (!$this->request->getParam('custSync')) {
-            $this->customersProcessor->resetCustomerSyncStatus(
-                $customer->getId(),
-                $customerStoreId,
-                1,
-                true
-            );
+            $this->customersAttributesService->updateSyncedToYotpoCustomerAttribute($customer, 0);
 
             $customerAddress = $customerAddress->getDefaultBilling() ? $customerAddress : null;
             if ($isCustomerSyncActive && $customerAddress) {
-                    /** @phpstan-ignore-next-line */
-                    $this->request->setParam('custSync', true);//to avoid multiple calls for a single save.
-                    $this->customersProcessor->processCustomer($customer, $customerAddress);
+                /** @phpstan-ignore-next-line */
+                $this->request->setParam('custSync', true);//to avoid multiple calls for a single save.
+                $this->customersProcessor->processCustomer($customer, $customerAddress);
             }
         }
     }

--- a/Observer/CustomerSaveAfter.php
+++ b/Observer/CustomerSaveAfter.php
@@ -82,7 +82,7 @@ class CustomerSaveAfter implements ObserverInterface
             $this->customersProcessor->resetCustomerSyncStatus(
                 $customer->getId(),
                 $customer->getStoreId(),
-                0,
+                1,
                 true
             );
             if ($isCustomerSyncActive) {

--- a/Observer/CustomerSaveAfter.php
+++ b/Observer/CustomerSaveAfter.php
@@ -85,27 +85,25 @@ class CustomerSaveAfter implements ObserverInterface
                 1,
                 true
             );
-            if ($isCustomerSyncActive) {
+
+            $isCheckoutInProgress = $this->request->getParam('_checkout_in_progress', null);
+            if ($isCustomerSyncActive && $isCheckoutInProgress === null) {
                 $isActive = 1;
                 /** @phpstan-ignore-next-line */
                 $this->request->setParam('custSync', true);//to avoid multiple calls for a single save.
-                $isCheckoutInProgress = $this->request->getParam('_checkout_in_progress', null);
-                if ($isCheckoutInProgress === null) {
-                    if ($this->appState->getAreaCode() == 'frontend') {
-                        /** @var Customer $customer */
-                        $customer->setData('is_active_yotpo', $isActive);
-                    } else {
-                        /** @phpstan-ignore-next-line */
-                        $postValue = $this->request->getPost('customer', null);
-                        if (is_array($postValue)
-                            && isset($postValue['is_active'])) {
-                            $isActive = $postValue['is_active'];
-                        }
-                        /** @var Customer $customer */
-                        $customer->setData('is_active_yotpo', $isActive);
-                    }
-                    $this->customersProcessor->processCustomer($customer);
+                /** @phpstan-ignore-next-line */
+                $postValue = $this->request->getPost('customer', null);
+
+                if ($this->appState->getAreaCode() == 'frontend') {
+                    /** @var Customer $customer */
+                    $customer->setData('is_active_yotpo', $isActive);
+                } elseif (is_array($postValue) && isset($postValue['is_active'])) {
+                    $isActive = $postValue['is_active'];
+                    /** @var Customer $customer */
+                    $customer->setData('is_active_yotpo', $isActive);
                 }
+
+                $this->customersProcessor->processCustomer($customer);
             }
         }
     }

--- a/Observer/CustomerSaveAfter.php
+++ b/Observer/CustomerSaveAfter.php
@@ -12,6 +12,7 @@ use Yotpo\SmsBump\Model\Config;
 use Magento\Framework\App\RequestInterface;
 use Magento\Checkout\Model\Session;
 use Magento\Framework\App\State as AppState;
+use Yotpo\SmsBump\Model\Sync\Customers\Services\CustomersAttributesService;
 
 /**
  * Class CustomerSaveAfter
@@ -45,25 +46,33 @@ class CustomerSaveAfter implements ObserverInterface
     protected $appState;
 
     /**
+     * @var CustomersAttributesService
+     */
+    protected $customersAttributesService;
+
+    /**
      * CustomerSaveAfter constructor.
      * @param CustomersProcessor $customersProcessor
      * @param Config $yotpoSmsConfig
      * @param RequestInterface $request
      * @param Session $session
      * @param AppState $appState
+     * @param CustomersAttributesService $customersAttributesService
      */
     public function __construct(
         CustomersProcessor $customersProcessor,
         Config $yotpoSmsConfig,
         RequestInterface $request,
         Session $session,
-        AppState $appState
+        AppState $appState,
+        CustomersAttributesService $customersAttributesService
     ) {
         $this->customersProcessor = $customersProcessor;
         $this->yotpoSmsConfig = $yotpoSmsConfig;
         $this->request = $request;
         $this->session = $session;
         $this->appState = $appState;
+        $this->customersAttributesService = $customersAttributesService;
     }
 
     /**
@@ -79,12 +88,7 @@ class CustomerSaveAfter implements ObserverInterface
         $customer = $observer->getEvent()->getCustomer();
         $isCustomerSyncActive = $this->yotpoSmsConfig->isCustomerSyncActive();
         if (!$this->request->getParam('custSync')) {
-            $this->customersProcessor->resetCustomerSyncStatus(
-                $customer->getId(),
-                $customer->getStoreId(),
-                1,
-                true
-            );
+            $this->customersAttributesService->updateSyncedToYotpoCustomerAttribute($customer, false);
 
             $isCheckoutInProgress = $this->request->getParam('_checkout_in_progress', null);
             if ($isCustomerSyncActive && $isCheckoutInProgress === null) {

--- a/Setup/Patch/Data/CustomCustomerAttributeSyncedToYotpo.php
+++ b/Setup/Patch/Data/CustomCustomerAttributeSyncedToYotpo.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Yotpo\SmsBump\Setup\Patch\Data;
+
+use Magento\Customer\Model\Customer;
+use Magento\Customer\Setup\CustomerSetupFactory;
+use Magento\Framework\Setup\ModuleDataSetupInterface;
+use Magento\Framework\Setup\Patch\DataPatchInterface;
+use Magento\Eav\Model\Entity\Attribute\ScopedAttributeInterface;
+use Yotpo\SmsBump\Model\Config as MessagingConfig;
+
+class CustomCustomerAttributeSyncedToYotpo implements DataPatchInterface
+{
+    const CUSTOMER_SETUP_FACTORY_SETUP_KEY = 'setup';
+
+    /**
+     * @var ModuleDataSetupInterface
+     */
+    private $moduleDataSetup;
+
+    /**
+     * @var CustomerSetupFactory
+     */
+    private $customerSetupFactory;
+
+    /**
+     * @var MessagingConfig
+     */
+    private $messagingConfig;
+
+    /**
+     * @param ModuleDataSetupInterface $moduleDataSetup
+     * @param CustomerSetupFactory $customerSetupFactory
+     * @param MessagingConfig $messagingConfig
+     */
+    public function __construct(
+        ModuleDataSetupInterface $moduleDataSetup,
+        CustomerSetupFactory $customerSetupFactory,
+        MessagingConfig $messagingConfig
+    ) {
+        $this->moduleDataSetup = $moduleDataSetup;
+        $this->customerSetupFactory = $customerSetupFactory;
+        $this->messagingConfig = $messagingConfig;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function apply()
+    {
+        $customerSetup = $this->customerSetupFactory->create([ $this::CUSTOMER_SETUP_FACTORY_SETUP_KEY => $this->moduleDataSetup ]);
+        $customerSetup->addAttribute(Customer::ENTITY, $this->messagingConfig::SYNCED_TO_YOTPO_CUSTOMER_ATTRIBUTE_NAME, [
+            'type' => 'int',
+            'label' => 'Synced to Yotpo Customer',
+            'required' => false,
+            'visible' => false,
+            'user_defined' => false
+        ]);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public static function getDependencies()
+    {
+        return [];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getAliases()
+    {
+        return [];
+    }
+}

--- a/etc/adminhtml/events.xml
+++ b/etc/adminhtml/events.xml
@@ -3,4 +3,7 @@
     <event name="admin_system_config_changed_section_yotpo_core">
         <observer name="yotpo_smsbump_admin_system_config_changed_section_yotpo" instance="Yotpo\SmsBump\Observer\Config\Save" />
     </event>
+    <event name="admin_system_config_changed_section_customer">
+        <observer name="yotpo_smsbump_admin_system_config_changed_section_customer" instance="Yotpo\SmsBump\Observer\Config\Customer\CustomerConfigSave" />
+    </event>
 </config>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -32,6 +32,11 @@
                             <cron_expr>*/2 * * * *</cron_expr>
                         </schedule>
                     </yotpo_cron_messaging_customers_sync>
+                    <yotpo_cron_messaging_customers_sync_retry>
+                        <schedule>
+                            <cron_expr>*/2 * * * *</cron_expr>
+                        </schedule>
+                    </yotpo_cron_messaging_customers_sync_retry>
                 </jobs>
             </yotpo_messaging_customers_sync>
         </crontab>

--- a/etc/crontab.xml
+++ b/etc/crontab.xml
@@ -4,5 +4,8 @@
         <job name="yotpo_cron_messaging_customers_sync" instance="Yotpo\SmsBump\Model\Sync\Customers\Cron\CustomersSync" method="execute">
             <config_path>crontab/yotpo_messaging_customers_sync/jobs/yotpo_cron_messaging_customers_sync/schedule/cron_expr</config_path>
         </job>
+        <job name="yotpo_cron_messaging_customers_sync_retry" instance="Yotpo\SmsBump\Model\Sync\Customers\Cron\CustomersSyncRetry" method="execute">
+            <config_path>crontab/yotpo_messaging_customers_sync/jobs/yotpo_cron_messaging_customers_sync_retry/schedule/cron_expr</config_path>
+        </job>
     </group>
 </config>

--- a/etc/crontab.xml
+++ b/etc/crontab.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Cron:etc/crontab.xsd">
     <group id="yotpo_messaging_customers_sync">
-        <job name="yotpo_cron_messaging_customers_sync" instance="Yotpo\SmsBump\Model\Sync\Customers\Cron\CustomersSync" method="processCustomers">
+        <job name="yotpo_cron_messaging_customers_sync" instance="Yotpo\SmsBump\Model\Sync\Customers\Cron\CustomersSync" method="execute">
             <config_path>crontab/yotpo_messaging_customers_sync/jobs/yotpo_cron_messaging_customers_sync/schedule/cron_expr</config_path>
         </job>
     </group>

--- a/etc/db_schema.xml
+++ b/etc/db_schema.xml
@@ -2,16 +2,12 @@
 <schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Setup/Declaration/Schema/etc/schema.xsd">
     <table name="yotpo_customers_sync" resource="default" engine="innodb" comment="Customers sync with Yotpo">
-        <column xsi:type="int" name="entity_id" unsigned="true" nullable="false" identity="true"
-                comment="Entity ID"/>
-        <column xsi:type="int" name="customer_id" unsigned="true" nullable="false" identity="false"
-                comment="Customer ID"/>
-        <column xsi:type="int" name="store_id" unsigned="true" nullable="false" identity="false" default="0"
-                comment="Store ID"/>
+        <column xsi:type="int" name="entity_id" unsigned="true" nullable="false" identity="true" comment="Entity ID"/>
+        <column xsi:type="int" name="customer_id" unsigned="true" nullable="false" identity="false" comment="Customer ID"/>
+        <column xsi:type="int" name="store_id" unsigned="true" nullable="false" identity="false" default="0" comment="Store ID"/>
         <column xsi:type="datetime" name="synced_to_yotpo" nullable="true" comment="Synced to Yotpo"/>
         <column xsi:type="varchar" name="response_code" nullable="true" length="5" comment="Response Code"/>
-        <column xsi:type="smallint" name="sync_status" unsigned="true" nullable="false" identity="false" default="0"
-                comment="Sync Status"/>
+        <column xsi:type="smallint" name="sync_status" unsigned="true" nullable="false" identity="false" default="0" comment="Sync Status"/>
         <constraint xsi:type="primary" referenceId="PRIMARY">
             <column name="entity_id"/>
         </constraint>
@@ -27,12 +23,9 @@
         </index>
     </table>
     <table name="yotpo_abandoned_cart" resource="default" engine="innodb" comment="Yotpo Abandoned Checkout">
-        <column xsi:type="int" name="abandoned_cart_id" unsigned="true" nullable="false" identity="true"
-                comment="Abandoned Card ID"/>
-        <column xsi:type="int" name="quote_id" padding="10" unsigned="true" nullable="false" identity="false"
-                default="0" comment="Quote ID"/>
-        <column xsi:type="smallint" name="store_id" unsigned="true" nullable="true" identity="false"
-                comment="Store ID"/>
+        <column xsi:type="int" name="abandoned_cart_id" unsigned="true" nullable="false" identity="true" comment="Abandoned Card ID"/>
+        <column xsi:type="int" name="quote_id" padding="10" unsigned="true" nullable="false" identity="false" default="0" comment="Quote ID"/>
+        <column xsi:type="smallint" name="store_id" unsigned="true" nullable="true" identity="false" comment="Store ID"/>
         <column xsi:type="varchar" name="email" nullable="true" length="255" comment="Email"/>
         <column xsi:type="varchar" name="quote_token" nullable="true" length="255" comment="Quote Token"/>
         <constraint xsi:type="primary" referenceId="PRIMARY">

--- a/etc/db_schema.xml
+++ b/etc/db_schema.xml
@@ -7,7 +7,6 @@
         <column xsi:type="int" name="store_id" unsigned="true" nullable="false" identity="false" default="0" comment="Store ID"/>
         <column xsi:type="datetime" name="synced_to_yotpo" nullable="true" comment="Synced to Yotpo"/>
         <column xsi:type="varchar" name="response_code" nullable="true" length="5" comment="Response Code"/>
-        <column xsi:type="smallint" name="sync_status" unsigned="true" nullable="false" identity="false" default="0" comment="Sync Status"/>
         <column xsi:type="smallint" name="should_retry" unsigned="true" nullable="false" identity="false" default="0" comment="Should Retry Sync"/>
         <constraint xsi:type="primary" referenceId="PRIMARY">
             <column name="entity_id"/>
@@ -18,9 +17,6 @@
         </constraint>
         <index referenceId="YOTPO_CUSTOMERS_SYNC_ENTITY_ID" indexType="btree">
             <column name="entity_id"/>
-        </index>
-        <index referenceId="YOTPO_CUSTOMERS_SYNC_SYNC_STATUS" indexType="btree">
-            <column name="sync_status"/>
         </index>
         <index referenceId="YOTPO_CUSTOMERS_SYNC_STORE_ID_SHOULD_RETRY" indexType="btree">
             <column name="store_id"/>

--- a/etc/db_schema.xml
+++ b/etc/db_schema.xml
@@ -8,6 +8,7 @@
         <column xsi:type="datetime" name="synced_to_yotpo" nullable="true" comment="Synced to Yotpo"/>
         <column xsi:type="varchar" name="response_code" nullable="true" length="5" comment="Response Code"/>
         <column xsi:type="smallint" name="sync_status" unsigned="true" nullable="false" identity="false" default="0" comment="Sync Status"/>
+        <column xsi:type="smallint" name="should_retry" unsigned="true" nullable="false" identity="false" default="0" comment="Should Retry Sync"/>
         <constraint xsi:type="primary" referenceId="PRIMARY">
             <column name="entity_id"/>
         </constraint>
@@ -20,6 +21,10 @@
         </index>
         <index referenceId="YOTPO_CUSTOMERS_SYNC_SYNC_STATUS" indexType="btree">
             <column name="sync_status"/>
+        </index>
+        <index referenceId="YOTPO_CUSTOMERS_SYNC_STORE_ID_SHOULD_RETRY" indexType="btree">
+            <column name="store_id"/>
+            <column name="should_retry"/>
         </index>
     </table>
     <table name="yotpo_abandoned_cart" resource="default" engine="innodb" comment="Yotpo Abandoned Checkout">

--- a/etc/db_schema_whitelist.json
+++ b/etc/db_schema_whitelist.json
@@ -6,11 +6,13 @@
             "store_id": true,
             "synced_to_yotpo": true,
             "response_code": true,
-            "sync_status": true
+            "sync_status": true,
+            "should_retry": true
         },
         "index": {
             "YOTPO_CUSTOMERS_SYNC_ENTITY_ID": true,
-            "YOTPO_CUSTOMERS_SYNC_SYNC_STATUS": true
+            "YOTPO_CUSTOMERS_SYNC_SYNC_STATUS": true,
+            "YOTPO_CUSTOMERS_SYNC_STORE_ID_SHOULD_RETRY": true
         },
         "constraint": {
             "PRIMARY": true,

--- a/etc/db_schema_whitelist.json
+++ b/etc/db_schema_whitelist.json
@@ -6,12 +6,10 @@
             "store_id": true,
             "synced_to_yotpo": true,
             "response_code": true,
-            "sync_status": true,
             "should_retry": true
         },
         "index": {
             "YOTPO_CUSTOMERS_SYNC_ENTITY_ID": true,
-            "YOTPO_CUSTOMERS_SYNC_SYNC_STATUS": true,
             "YOTPO_CUSTOMERS_SYNC_STORE_ID_SHOULD_RETRY": true
         },
         "constraint": {

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -92,6 +92,7 @@
     <type name="Yotpo\Core\Model\System\Message\CustomSystemMessage">
         <arguments>
             <argument name="customCustomerAttributeSmsMarketing" xsi:type="object">Yotpo\SmsBump\Setup\Patch\Data\CustomCustomerAttributeSmsMarketing</argument>
+            <argument name="CustomCustomerAttributeSyncedToYotpo" xsi:type="object">Yotpo\SmsBump\Setup\Patch\Data\SyncedToYotpoCustomerAttribute</argument>
         </arguments>
     </type>
 </config>


### PR DESCRIPTION
**Includes logic and code from #98.**

## Description
The customers sync was based on getting customer collections for sync, using JOIN with the entire `customers_entity` table and `yotpo_customers_sync` - which caused in turn timeouts in big data sets.
This is a highly inefficient and un-scaleable method, which was poorly performing during our QA and tests.

## Solution
In this PR, we're creating a new logic for syncing customers to Yotpo.
It includes using a Magento EAV attribute and a new cron for retrying failed entities sync.
The new cron is handling retrying failed customers from the original cron, that weren't sync properly using the Yotpo API.
The attribute is set by both observers and cron processes.

### Cases that were taken into consideration:
* Backfill existing customers.
* Create customer from store view.
* Update customer from store view.
* Create customer from admin view.
* Update customer from admin view.
* Switching customer share config from website to global, which should reset the customers sync.
* Switching customer share config from global to website, which should do nothing.
* Change values in the sync table and make sure customers are re-synced.
* Multisite with Yotpo on/off in one/all of the stores.

Further than that, this PR also includes some extensive refactoring to the customer syncing process.