### PR TITLE
COR-2003 add customer attribute if deleted

### DIFF
--- a/Setup/Patch/Data/CustomCustomerAttributeSyncedToYotpo.php
+++ b/Setup/Patch/Data/CustomCustomerAttributeSyncedToYotpo.php
@@ -2,6 +2,7 @@
 
 namespace Yotpo\SmsBump\Setup\Patch\Data;
 
+use Yotpo\Core\Model\CustomCustomerAttributeSyncedToYotpo as CoreCustomCustomerAttributeSyncedToYotpo;
 use Magento\Customer\Model\Customer;
 use Magento\Customer\Setup\CustomerSetupFactory;
 use Magento\Framework\Setup\ModuleDataSetupInterface;
@@ -9,7 +10,7 @@ use Magento\Framework\Setup\Patch\DataPatchInterface;
 use Magento\Eav\Model\Entity\Attribute\ScopedAttributeInterface;
 use Yotpo\SmsBump\Model\Config as MessagingConfig;
 
-class CustomCustomerAttributeSyncedToYotpo implements DataPatchInterface
+class CustomCustomerAttributeSyncedToYotpo extends CoreCustomCustomerAttributeSyncedToYotpo implements DataPatchInterface
 {
     const CUSTOMER_SETUP_FACTORY_SETUP_KEY = 'setup';
 

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -92,7 +92,7 @@
     <type name="Yotpo\Core\Model\System\Message\CustomSystemMessage">
         <arguments>
             <argument name="customCustomerAttributeSmsMarketing" xsi:type="object">Yotpo\SmsBump\Setup\Patch\Data\CustomCustomerAttributeSmsMarketing</argument>
-            <argument name="CustomCustomerAttributeSyncedToYotpo" xsi:type="object">Yotpo\SmsBump\Setup\Patch\Data\SyncedToYotpoCustomerAttribute</argument>
+            <argument name="customCustomerAttributeSyncedToYotpo" xsi:type="object">Yotpo\SmsBump\Setup\Patch\Data\CustomCustomerAttributeSyncedToYotpo</argument>
         </arguments>
     </type>
 </config>


### PR DESCRIPTION
Completing https://github.com/YotpoLtd/magento2-module-core/pull/183.

## Description
The core module has a feature of re-creating attributes if they were deleted.
This PR adds this functionality to the customers sync attribute creator class, `CustomCustomerAttributeSyncedToYotpo`.