### PR TITLE
COR-2137 skip checkout sync for quotes without ID

### DIFF
--- a/Plugin/Quote/Model/AbstractCheckoutTrigger.php
+++ b/Plugin/Quote/Model/AbstractCheckoutTrigger.php
@@ -61,6 +61,10 @@ class AbstractCheckoutTrigger
     protected function checkoutSync(QuoteModel $quote)
     {
         if ($this->yotpoMessagingConfig->isCheckoutSyncActive()) {
+            if (!$quote->getId()) {
+                return;
+            }
+
             $billingAddress = $quote->getBillingAddress();
             if (!$billingAddress->getCountryId()) {
                 return;

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "yotpo/module-yotpo-messaging",
     "description": "Yotpo Sms extension for Magento2",
-    "version": "4.0.27",
+    "version": "4.0.28",
     "license": [
         "OSL-3.0",
         "AFL-3.0"
@@ -9,7 +9,7 @@
     "require": {
         "php": "~5.6.0|^7.0|^8.0",
         "magento/framework": ">=102.0.0",
-        "yotpo/module-yotpo-core": "4.0.27"
+        "yotpo/module-yotpo-core": "4.0.28"
     },
     "type": "magento2-module",
     "autoload": {

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Yotpo_SmsBump" setup_version="4.0.27">
+    <module name="Yotpo_SmsBump" setup_version="4.0.28">
         <sequence>
             <Yotpo_Core/>
         </sequence>


### PR DESCRIPTION
With the following PRs:
- https://github.com/YotpoLtd/magento2-module-core/pull/204
- https://github.com/YotpoLtd/magento2-module-reviews/pull/76
- https://github.com/YotpoLtd/magento2-module-combined/pull/71

## Jira Ticket
https://jira.yotpo.com/browse/COR-2137

## Description
The re-order process failes as afterSetBillingAddress observer is being triggered, which executes a checkout sync with a Quote object.
However, the address is set before the Quote was actually saved, which means the Quote doesn't have an ID yet.
When trying to save a reference to the Quote in yotpo_abandoned_carts table, the INSERT query fails as quote_id column is non-nullable.

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/45664120/175068564-3886242b-7907-4585-ba64-d11332bbbd5c.png">

