### PR TITLE
COR-2220 pass origin request params in abandoned cart redirection

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "yotpo/module-yotpo-messaging",
     "description": "Yotpo Sms extension for Magento2",
-    "version": "4.0.28",
+    "version": "4.0.29",
     "license": [
         "OSL-3.0",
         "AFL-3.0"
@@ -9,7 +9,7 @@
     "require": {
         "php": "~5.6.0|^7.0|^8.0",
         "magento/framework": ">=102.0.0",
-        "yotpo/module-yotpo-core": "4.0.28"
+        "yotpo/module-yotpo-core": "4.0.29"
     },
     "type": "magento2-module",
     "autoload": {

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Yotpo_SmsBump" setup_version="4.0.28">
+    <module name="Yotpo_SmsBump" setup_version="4.0.29">
         <sequence>
             <Yotpo_Core/>
         </sequence>


### PR DESCRIPTION
## Developer Notes
Passing origin request params when redirecting a customer to a cart page via the abandoned cart process.

## Related PRs
- https://github.com/YotpoLtd/magento2-module-core/pull/205
- https://github.com/YotpoLtd/magento2-module-reviews/pull/77
- https://github.com/YotpoLtd/magento2-module-combined/pull/72