### PR TITLE
COR-2246 support form_additional_info for customer registration form

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "yotpo/module-yotpo-messaging",
     "description": "Yotpo Sms extension for Magento2",
-    "version": "4.0.29",
+    "version": "4.0.30",
     "license": [
         "OSL-3.0",
         "AFL-3.0"
@@ -9,7 +9,7 @@
     "require": {
         "php": "~5.6.0|^7.0|^8.0",
         "magento/framework": ">=102.0.0",
-        "yotpo/module-yotpo-core": "4.0.29"
+        "yotpo/module-yotpo-core": "4.0.30"
     },
     "type": "magento2-module",
     "autoload": {

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Yotpo_SmsBump" setup_version="4.0.29">
+    <module name="Yotpo_SmsBump" setup_version="4.0.30">
         <sequence>
             <Yotpo_Core/>
         </sequence>

--- a/view/frontend/templates/customer/form/register.phtml
+++ b/view/frontend/templates/customer/form/register.phtml
@@ -169,6 +169,11 @@ use Magento\Customer\Block\Form\Register;
             </div>
         </div>
     </fieldset>
+
+    <fieldset class="fieldset additional_info">
+        <?= $block->getChildHtml('form_additional_info') ?>
+    </fieldset>
+
     <div class="actions-toolbar">
         <div class="primary">
             <button type="submit" class="action submit primary" title="<?= $block->escapeHtmlAttr(__('Create an Account')) ?>"><span><?= $block->escapeHtml(__('Create an Account')) ?></span></button>


### PR DESCRIPTION
## Developer Notes
The customer registration form for Magento CE was missing injection of form_additional_info fieldset.
This caused the Google ReCaptcha to not be injected for customers who are using it in the form.
Tested with Magento CE v2.4.4.

## Related PRs
* https://github.com/YotpoLtd/magento2-module-core/pull/206
* https://github.com/YotpoLtd/magento2-module-reviews/pull/78
* https://github.com/YotpoLtd/magento2-module-combined/pull/73