### PR TITLE
COR-2254 added Browse Abandonment feature implementation

### DIFF
--- a/Block/BrowseAbandonment.php
+++ b/Block/BrowseAbandonment.php
@@ -1,0 +1,292 @@
+<?php
+namespace Yotpo\SmsBump\Block;
+
+use Magento\Framework\Registry;
+use Magento\Framework\View\Element\Template\Context;
+use Yotpo\SmsBump\Model\Config as YotpoConfig;
+use Magento\Framework\View\Element\Template;
+use Magento\Customer\Model\Session as CustomerModelSession;
+use Magento\Framework\App\Request\Http as HttpRequest;
+use Magento\Checkout\Model\SessionFactory as CheckoutSessionFactory;
+
+/**
+ * Class BrowseAbandonment - Block file for Browse Abandonment script injection
+ */
+class BrowseAbandonment extends Template
+{
+    /**
+     * @const string
+     */
+    const MAGENTO_HOME_PAGE_TYPE_NAME = 'cms_index_index';
+
+    /**
+     * @const string
+     */
+    const MAGENTO_CATEGORY_PAGE_TYPE_NAME = 'catalog_category_view';
+
+    /**
+     * @const string
+     */
+    const MAGENTO_PRODUCT_PAGE_TYPE_NAME = 'catalog_product_view';
+
+    /**
+     * @const string
+     */
+    const MAGENTO_ORDER_CREATED_PAGE_TYPE_NAME = 'checkout_onepage_success';
+
+    /**
+     * @const array<string>
+     */
+    const ELIGIBLE_MAGENTO_PAGE_TYPE_NAMES_FOR_BROWSE_ABANDONMENT = [
+        self::MAGENTO_HOME_PAGE_TYPE_NAME,
+        self::MAGENTO_CATEGORY_PAGE_TYPE_NAME,
+        self::MAGENTO_PRODUCT_PAGE_TYPE_NAME,
+        self::MAGENTO_ORDER_CREATED_PAGE_TYPE_NAME
+    ];
+
+    /**
+     * @const string
+     */
+    const BROWSE_ABANDONMENT_HOME_PAGE_TYPE_NAME = 'home';
+
+    /**
+     * @const string
+     */
+    const BROWSE_ABANDONMENT_COLLECTION_PAGE_TYPE_NAME = 'collection';
+
+    /**
+     * @const string
+     */
+    const BROWSE_ABANDONMENT_PRODUCT_PAGE_TYPE_NAME = 'product';
+
+    /**
+     * @const string
+     */
+    const BROWSE_ABANDONMENT_ORDER_CREATED_PAGE_TYPE_NAME = 'order_created';
+
+    /**
+     * @const array<string, string>
+     */
+    const MAGENTO_PAGE_TYPE_NAME_TO_BROWSE_ABANDONMENT_PAGE_TYPE_NAME_MAP = [
+        self::MAGENTO_HOME_PAGE_TYPE_NAME => self::BROWSE_ABANDONMENT_HOME_PAGE_TYPE_NAME,
+        self::MAGENTO_CATEGORY_PAGE_TYPE_NAME => self::BROWSE_ABANDONMENT_COLLECTION_PAGE_TYPE_NAME,
+        self::MAGENTO_PRODUCT_PAGE_TYPE_NAME => self::BROWSE_ABANDONMENT_PRODUCT_PAGE_TYPE_NAME,
+        self::MAGENTO_ORDER_CREATED_PAGE_TYPE_NAME => self::BROWSE_ABANDONMENT_ORDER_CREATED_PAGE_TYPE_NAME
+    ];
+
+    /**
+     * @const array<string>
+     */
+    const BROWSE_ABANDONMENT_PAGE_TYPE_NAMES_ELIGIBLE_FOR_ID_ENRICHMENT = [
+        self::BROWSE_ABANDONMENT_COLLECTION_PAGE_TYPE_NAME,
+        self::BROWSE_ABANDONMENT_PRODUCT_PAGE_TYPE_NAME
+    ];
+
+    /**
+     * @var YotpoConfig
+     */
+    private $yotpoConfig;
+
+    /**
+     * @var Registry
+     */
+    private $coreRegistry;
+
+    /**
+     * @var CustomerModelSession
+     */
+    private $customerModelSession;
+
+    /**
+     * @var HttpRequest
+     */
+    private $httpRequest;
+
+    /**
+     * @var CheckoutSessionFactory
+     */
+    private $checkoutSessionFactory;
+
+    /**
+     * BrowseAbandonment constructor.
+     * @param Context $context
+     * @param YotpoConfig $yotpoConfig
+     * @param Registry $coreRegistry
+     * @param CustomerModelSession $customerModelSession
+     * @param HttpRequest $httpRequest
+     * @param CheckoutSessionFactory $checkoutSessionFactory
+     * @param array<mixed> $templateData
+     */
+    public function __construct(
+        Context $context,
+        YotpoConfig $yotpoConfig,
+        Registry $coreRegistry,
+        CustomerModelSession $customerModelSession,
+        HttpRequest $httpRequest,
+        CheckoutSessionFactory $checkoutSessionFactory,
+        array $templateData = []
+    ) {
+        $this->yotpoConfig = $yotpoConfig;
+        $this->coreRegistry = $coreRegistry;
+        $this->customerModelSession = $customerModelSession;
+        $this->httpRequest = $httpRequest;
+        $this->checkoutSessionFactory = $checkoutSessionFactory;
+        parent::__construct($context, $templateData);
+    }
+
+    /**
+     * Check module is enabled and API tokens set
+     *
+     * @return boolean
+     * @throws LocalizedException
+     * @throws NoSuchEntityException
+     */
+    public function isAppKeyAndSecretSet()
+    {
+        return $this->yotpoConfig->isAppKeyAndSecretSet();
+    }
+
+    /**
+     * Get if page type is eligible for Browse Abandonment event
+     *
+     * @return boolean
+     */
+    public function isPageTypeEligibleForBrowseAbandonmentEvent()
+    {
+        $magentoPageTypeName = $this->getMagentoPageTypeName();
+        return in_array($magentoPageTypeName, self::ELIGIBLE_MAGENTO_PAGE_TYPE_NAMES_FOR_BROWSE_ABANDONMENT);
+    }
+
+    /**
+     * Get Browse Abandonment event info
+     *
+     * @return string
+     */
+    public function getBrowseAbandonmentEventInfo()
+    {
+        $browseAbandonmentPageType = $this->getBrowseAbandonmentPageType();
+        $browseAbandonmentEventInfo = [];
+        $browseAbandonmentEventInfo['type'] = $browseAbandonmentPageType;
+        $browseAbandonmentEventInfo['data'] = $this->getBrowseAbandonmentEventInfoData($browseAbandonmentPageType);
+        return json_encode($browseAbandonmentEventInfo);
+    }
+
+    /**
+     * Get Browse Abandonment event info data
+     *
+     * @return array
+     */
+    private function getBrowseAbandonmentEventInfoData($browseAbandonmentPageType) {
+        $browseAbandonmentInfoData = [];
+        $browseAbandonmentInfoData['type'] = $browseAbandonmentPageType;
+        $browseAbandonmentInfoData['store_id'] = $this->getStoreId();
+
+        $browseAbandonmentEligiblePageTypeEntityId = $this->getIdByBrowseAbandonmentPageType($browseAbandonmentPageType);
+        if ($browseAbandonmentEligiblePageTypeEntityId) {
+            $browseAbandonmentInfoData['id'] = $browseAbandonmentEligiblePageTypeEntityId;
+        }
+
+        $customerIdInSession = $this->getCustomerIdInSession();
+        if ($customerIdInSession) {
+            $browseAbandonmentInfoData['customer_id'] = $customerIdInSession;
+        }
+
+        if ($browseAbandonmentPageType === self::BROWSE_ABANDONMENT_ORDER_CREATED_PAGE_TYPE_NAME) {
+            $browseAbandonmentInfoData['order_id'] = $this->getOrderIdInOrderCreatedPage();
+        }
+
+        return $browseAbandonmentInfoData;
+    }
+
+    /**
+     * Get the name of the browse abandonment page type according to magento page type
+     *
+     * @return string
+     */
+    private function getBrowseAbandonmentPageType() {
+        $magentoPageTypeName = $this->getMagentoPageTypeName();
+        return self::MAGENTO_PAGE_TYPE_NAME_TO_BROWSE_ABANDONMENT_PAGE_TYPE_NAME_MAP[$magentoPageTypeName];
+    }
+
+    /**
+     * Get the magento page type from request
+     *
+     * @return string
+     */
+    private function getMagentoPageTypeName()
+    {
+        return $this->httpRequest->getFullActionName();
+    }
+
+    /**
+     * Get Yotpo API Key
+     *
+     * @return string
+     */
+    private function getStoreId()
+    {
+        return $this->yotpoConfig->getAppKey();
+    }
+
+    /**
+     * Get ID for Browse Abandonment page type
+     *
+     * @param string $browseAbandonmentPageType
+     * @return int
+     */
+    private function getIdByBrowseAbandonmentPageType($browseAbandonmentPageType) {
+        if (!in_array($browseAbandonmentPageType, self::BROWSE_ABANDONMENT_PAGE_TYPE_NAMES_ELIGIBLE_FOR_ID_ENRICHMENT)) {
+            return null;
+        }
+
+        switch ($browseAbandonmentPageType) {
+            case self::BROWSE_ABANDONMENT_PRODUCT_PAGE_TYPE_NAME:
+                return $this->getProductId();
+            case self::BROWSE_ABANDONMENT_COLLECTION_PAGE_TYPE_NAME:
+                return $this->getCategoryId();
+            default:
+                return null;
+        }
+    }
+
+    /**
+     * Get Product ID from product object
+     *
+     * @return int
+     */
+    private function getProductId()
+    {
+        $product = $this->coreRegistry->registry('current_product');
+        return $product->getId();
+    }
+
+    /**
+     * Get Category ID from category object
+     *
+     * @return int
+     */
+    private function getCategoryId() {
+        $category = $this->coreRegistry->registry('current_category');
+        return $category->getId();
+    }
+
+    /**
+     * Get customer ID in current session
+     *
+     * @return int
+     */
+    private function getCustomerIdInSession() {
+        return $this->customerModelSession->getCustomer()->getId();
+    }
+
+    /**
+     * Get order ID in current checkout session
+     *
+     * @return int
+     */
+    private function getOrderIdInOrderCreatedPage()
+    {
+        $checkoutSession = $this->checkoutSessionFactory->create();
+        return $checkoutSession->getLastRealOrder()->getIncrementId();
+    }
+}

--- a/etc/csp_whitelist.xml
+++ b/etc/csp_whitelist.xml
@@ -4,6 +4,7 @@
         <policy id="script-src">
             <values>
                 <value id="sync-forms" type="host">dhv2ziothpgrr.cloudfront.net</value>
+                <value id="browse-abandonment" type="host">d18eg7dreypte5.cloudfront.net</value>
             </values>
         </policy>
         <policy id="connect-src">

--- a/view/frontend/layout/default.xml
+++ b/view/frontend/layout/default.xml
@@ -3,12 +3,12 @@
       xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="head.additional">
-            <block class="Magento\Framework\View\Element\Template" name="sync_subscription"
-                   template="Yotpo_SmsBump::sync_forms.phtml">
+            <block class="Magento\Framework\View\Element\Template" name="sync_subscription" template="Yotpo_SmsBump::sync_forms.phtml">
                 <arguments>
                     <argument name="sync_forms_response" xsi:type="object">Yotpo\SmsBump\ViewModel\SyncForms</argument>
                 </arguments>
             </block>
+            <block class="Yotpo\SmsBump\Block\BrowseAbandonment" name="browse_abandonment" template="Yotpo_SmsBump::browse_abandonment.phtml" ifconfig="yotpo_core/settings/active"/>
         </referenceContainer>
     </body>
 </page>

--- a/view/frontend/layout/default.xml
+++ b/view/frontend/layout/default.xml
@@ -3,7 +3,7 @@
       xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="head.additional">
-            <block class="Magento\Framework\View\Element\Template" name="sync_subscription" template="Yotpo_SmsBump::sync_forms.phtml">
+            <block class="Magento\Framework\View\Element\Template" name="sync_subscription" template="Yotpo_SmsBump::sync_forms.phtml" ifconfig="yotpo_core/settings/active">
                 <arguments>
                     <argument name="sync_forms_response" xsi:type="object">Yotpo\SmsBump\ViewModel\SyncForms</argument>
                 </arguments>

--- a/view/frontend/templates/browse_abandonment.phtml
+++ b/view/frontend/templates/browse_abandonment.phtml
@@ -1,0 +1,16 @@
+<?php
+/**
+ * @var Yotpo\SmsBump\Block\BrowseAbandonment $block
+ */
+?>
+
+<?php if (!($block->isAppKeyAndSecretSet() && $block->isPageTypeEligibleForBrowseAbandonmentEvent())) {
+    return;
+}
+?>
+
+<script>
+    require(['https://d18eg7dreypte5.cloudfront.net/browse-abandonment/browse_abandonment_magento.js'])
+    window.wtba = window.wtba || [];
+    window.wtba.push(<?= $block->getBrowseAbandonmentEventInfo() ?>);
+</script>


### PR DESCRIPTION
## Developer Notes
This PR implements SMS Browse Abandonment feature to the Magento module.
I've created a new `BrowseAbandonment` Template-type class in order to support `browse_abandonment.phtml`.

The _phtml_ file does 2 things:
1. Requires the Browse Abandonment script.
2. Invokes `BrowseAbandonment::getBrowseAbandonmentEventInfo()` in order to build and inject the required data into `wtba` cookie.

The script and data are injected only when:
1. Yotpo module is enabled.
2. Proper store ID and secret are configured.
4. The shopper is on one of the supported pages - home, category, product, or order creation confirmation page.