### PR TITLE
COR-FIX add smsbump to script-src

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "yotpo/module-yotpo-messaging",
     "description": "Yotpo Sms extension for Magento2",
-    "version": "4.0.30",
+    "version": "4.0.31",
     "license": [
         "OSL-3.0",
         "AFL-3.0"
@@ -9,7 +9,7 @@
     "require": {
         "php": "~5.6.0|^7.0|^8.0",
         "magento/framework": ">=102.0.0",
-        "yotpo/module-yotpo-core": "4.0.30"
+        "yotpo/module-yotpo-core": "4.0.31"
     },
     "type": "magento2-module",
     "autoload": {

--- a/etc/csp_whitelist.xml
+++ b/etc/csp_whitelist.xml
@@ -4,6 +4,7 @@
         <policy id="script-src">
             <values>
                 <value id="sync-forms" type="host">dhv2ziothpgrr.cloudfront.net</value>
+                <value id="sync-forms-subscription" type="host">*.smsbump.com</value>
                 <value id="browse-abandonment" type="host">d18eg7dreypte5.cloudfront.net</value>
             </values>
         </policy>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Yotpo_SmsBump" setup_version="4.0.30">
+    <module name="Yotpo_SmsBump" setup_version="4.0.31">
         <sequence>
             <Yotpo_Core/>
         </sequence>


### PR DESCRIPTION
## Developer Notes
Added `*.smsbump.com` to script-src in order for SMS assets to load onsite.

## Related PRs:
- https://github.com/YotpoLtd/magento2-module-core/pull/210
- https://github.com/YotpoLtd/magento2-module-reviews/pull/80
- https://github.com/YotpoLtd/magento2-module-combined/pull/74