### PR TITLE
CO-149 fix(Checkout/Data):fixed passing null value to explode method

### DIFF
--- a/Model/Sync/Checkout/Data.php
+++ b/Model/Sync/Checkout/Data.php
@@ -283,7 +283,12 @@ class Data
         }
         try {
             foreach ($quote->getAllVisibleItems() as $item) {
-                $itemRuleIds = explode(',', $item->getAppliedRuleIds());
+                $appliedRuleIds = $item->getAppliedRuleIds();
+                $itemRuleIds = [];
+                if ($appliedRuleIds !== null) {
+                    $itemRuleIds = explode(',', $appliedRuleIds);
+                }
+
                 if ($ruleId != null || !in_array($ruleId, $itemRuleIds)) {
                     $couponCode = null;
                 }

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "yotpo/module-yotpo-messaging",
     "description": "Yotpo Sms extension for Magento2",
-    "version": "4.0.32",
+    "version": "4.0.33",
     "license": [
         "OSL-3.0",
         "AFL-3.0"
@@ -9,7 +9,7 @@
     "require": {
         "php": "~5.6.0|^7.0|^8.0",
         "magento/framework": ">=102.0.0",
-        "yotpo/module-yotpo-core": "4.0.32"
+        "yotpo/module-yotpo-core": "4.0.33"
     },
     "type": "magento2-module",
     "autoload": {

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Yotpo_SmsBump" setup_version="4.0.32">
+    <module name="Yotpo_SmsBump" setup_version="4.0.33">
         <sequence>
             <Yotpo_Core/>
         </sequence>


### PR DESCRIPTION
Passing null value to `explode` method was deprecated in PHP 8.1.