### PR TITLE
SMSPC-561 Base changes for improved customer behaviour tracking

### DIFF
--- a/Block/BrowseAbandonment.php
+++ b/Block/BrowseAbandonment.php
@@ -5,7 +5,6 @@ use Magento\Framework\Registry;
 use Magento\Framework\View\Element\Template\Context;
 use Yotpo\SmsBump\Model\Config as YotpoConfig;
 use Magento\Framework\View\Element\Template;
-use Magento\Customer\Model\Session as CustomerModelSession;
 use Magento\Framework\App\Request\Http as HttpRequest;
 use Magento\Checkout\Model\SessionFactory as CheckoutSessionFactory;
 
@@ -93,11 +92,6 @@ class BrowseAbandonment extends Template
     private $coreRegistry;
 
     /**
-     * @var CustomerModelSession
-     */
-    private $customerModelSession;
-
-    /**
      * @var HttpRequest
      */
     private $httpRequest;
@@ -112,23 +106,20 @@ class BrowseAbandonment extends Template
      * @param Context $context
      * @param YotpoConfig $yotpoConfig
      * @param Registry $coreRegistry
-     * @param CustomerModelSession $customerModelSession
      * @param HttpRequest $httpRequest
      * @param CheckoutSessionFactory $checkoutSessionFactory
      * @param array<mixed> $templateData
      */
     public function __construct(
-        Context $context,
-        YotpoConfig $yotpoConfig,
-        Registry $coreRegistry,
-        CustomerModelSession $customerModelSession,
-        HttpRequest $httpRequest,
+        Context                $context,
+        YotpoConfig            $yotpoConfig,
+        Registry               $coreRegistry,
+        HttpRequest            $httpRequest,
         CheckoutSessionFactory $checkoutSessionFactory,
         array $templateData = []
     ) {
         $this->yotpoConfig = $yotpoConfig;
         $this->coreRegistry = $coreRegistry;
-        $this->customerModelSession = $customerModelSession;
         $this->httpRequest = $httpRequest;
         $this->checkoutSessionFactory = $checkoutSessionFactory;
         parent::__construct($context, $templateData);
@@ -179,16 +170,10 @@ class BrowseAbandonment extends Template
     private function getBrowseAbandonmentEventInfoData($browseAbandonmentPageType) {
         $browseAbandonmentInfoData = [];
         $browseAbandonmentInfoData['type'] = $browseAbandonmentPageType;
-        $browseAbandonmentInfoData['store_id'] = $this->getStoreId();
 
         $browseAbandonmentEligiblePageTypeEntityId = $this->getIdByBrowseAbandonmentPageType($browseAbandonmentPageType);
         if ($browseAbandonmentEligiblePageTypeEntityId) {
             $browseAbandonmentInfoData['id'] = $browseAbandonmentEligiblePageTypeEntityId;
-        }
-
-        $customerIdInSession = $this->getCustomerIdInSession();
-        if ($customerIdInSession) {
-            $browseAbandonmentInfoData['customer_id'] = $customerIdInSession;
         }
 
         if ($browseAbandonmentPageType === self::BROWSE_ABANDONMENT_ORDER_CREATED_PAGE_TYPE_NAME) {
@@ -223,7 +208,7 @@ class BrowseAbandonment extends Template
      *
      * @return string
      */
-    private function getStoreId()
+    public function getStoreId()
     {
         return $this->yotpoConfig->getAppKey();
     }
@@ -268,15 +253,6 @@ class BrowseAbandonment extends Template
     private function getCategoryId() {
         $category = $this->coreRegistry->registry('current_category');
         return $category->getId();
-    }
-
-    /**
-     * Get customer ID in current session
-     *
-     * @return int
-     */
-    private function getCustomerIdInSession() {
-        return $this->customerModelSession->getCustomer()->getId();
     }
 
     /**

--- a/CustomerData/CustomerBehaviour.php
+++ b/CustomerData/CustomerBehaviour.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Yotpo\SmsBump\CustomerData;
+
+use Magento\Customer\CustomerData\SectionSourceInterface;
+use Magento\Customer\Helper\Session\CurrentCustomer;
+use Yotpo\SmsBump\Model\Session;
+
+/**
+ * CustomerData implementations for our "yotposms-customer-behaviour" private content section
+ */
+class CustomerBehaviour implements SectionSourceInterface
+{
+    private CurrentCustomer $currentCustomer;
+
+    public function __construct(CurrentCustomer $currentCustomer, Session $session)
+    {
+        $this->currentCustomer = $currentCustomer;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getSectionData(): array
+    {
+        $customer_id = $this->currentCustomer->getCustomerId();
+
+        return compact('customer_id');
+    }
+}

--- a/etc/frontend/di.xml
+++ b/etc/frontend/di.xml
@@ -1,5 +1,12 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <type name="Magento\Customer\CustomerData\SectionPoolInterface">
+        <arguments>
+            <argument name="sectionSourceMap" xsi:type="array">
+                <item name="yotposms-customer-behaviour" xsi:type="string">Yotpo\SmsBump\CustomerData\CustomerBehaviour</item>
+            </argument>
+        </arguments>
+    </type>
     <type name="Magento\Checkout\Model\CompositeConfigProvider">
         <arguments>
             <argument name="configProviders" xsi:type="array">

--- a/etc/frontend/sections.xml
+++ b/etc/frontend/sections.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © 2016 Magento. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Customer:etc/sections.xsd">
+    <!-- invalidates the "compare-products" section when a user
+    adds a product to the comparison, resulting in a "catalog/product_compare/add" POST request -->
+    <action name="customer/account/login">
+        <section name="yotposms-customer-behaviour"/>
+    </action>
+    <action name="customer/account/logout">
+        <section name="yotposms-customer-behaviour"/>
+    </action>
+</config>

--- a/view/frontend/requirejs-config.js
+++ b/view/frontend/requirejs-config.js
@@ -6,5 +6,8 @@ var config = {
             smsMarketingShipping: 'Yotpo_SmsBump/js/view/shipping/smsMarketing',
             removeLocalStorage:'Yotpo_SmsBump/js/removeLocalStorage'
         }
-    }
+    },
+    paths: {
+        YotpoSMS: 'https://d18eg7dreypte5.cloudfront.net/browse-abandonment/v2/magento',
+    },
 };

--- a/view/frontend/templates/browse_abandonment.phtml
+++ b/view/frontend/templates/browse_abandonment.phtml
@@ -4,13 +4,21 @@
  */
 ?>
 
-<?php if (!($block->isAppKeyAndSecretSet() && $block->isPageTypeEligibleForBrowseAbandonmentEvent())) {
+<?php if (!($block->isAppKeyAndSecretSet())) {
     return;
 }
 ?>
+<script type="text/x-magento-init">
+    {
+        "*": {
+           "YotpoSMS": { "store_id": "<?= $block->getStoreId() ?>" }
+        }
+    }
+</script>
 
 <script>
-    require(['https://d18eg7dreypte5.cloudfront.net/browse-abandonment/browse_abandonment_magento.js'])
     window.wtba = window.wtba || [];
+    <?php if ($block->isPageTypeEligibleForBrowseAbandonmentEvent()): ?>
     window.wtba.push(<?= $block->getBrowseAbandonmentEventInfo() ?>);
+    <?php endif; ?>
 </script>


### PR DESCRIPTION
This PR aims to be the stepping stone to further improve our customer behaviour tracking for Magento/AdobeCommerce such as tracking products added to cart for the purpose of segmentation and flows.

Also as we discussed earlier, we will improve how we collect customer data, such as `customer_id`, so we comply with Magento's best practices and keep our module compatible with full-page cache.

Changes summary:

* Introduce a private section `yotposms-customer-behaviour` that will be keep customer data. Atm only `customer_id`. Data is kept in local storage and Magento is updating it on login/logout. 
* We want to have our tracking JS at all times (similar to Shopify) so we could be able to identify customers when they fill subscription forms for example, so we (re)moved the condition for page eligibility for the script to be loaded.
* Instead of placing our JS tracking directly in the template we first register it in `requirejs-config.js` then use a declarative syntax to include it like a component, which allows us to set the `store_id` only once and not pass it along with page view data.
* We have updated the URL to our tracking JS script. New version supports being executed as AMD component which we now utilize.
* We have removed obsolete data generation in BrowseAbandonment block since we now get it from the private content section.