### PR TITLE
SMSPC-535 Track add to cart events

### DIFF
--- a/Block/BrowseAbandonment.php
+++ b/Block/BrowseAbandonment.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Yotpo\SmsBump\Block;
 
 use Magento\Framework\Registry;
@@ -116,8 +117,9 @@ class BrowseAbandonment extends Template
         Registry               $coreRegistry,
         HttpRequest            $httpRequest,
         CheckoutSessionFactory $checkoutSessionFactory,
-        array $templateData = []
-    ) {
+        array                  $templateData = []
+    )
+    {
         $this->yotpoConfig = $yotpoConfig;
         $this->coreRegistry = $coreRegistry;
         $this->httpRequest = $httpRequest;
@@ -167,7 +169,8 @@ class BrowseAbandonment extends Template
      *
      * @return array
      */
-    private function getBrowseAbandonmentEventInfoData($browseAbandonmentPageType) {
+    private function getBrowseAbandonmentEventInfoData($browseAbandonmentPageType)
+    {
         $browseAbandonmentInfoData = [];
         $browseAbandonmentInfoData['type'] = $browseAbandonmentPageType;
 
@@ -188,7 +191,8 @@ class BrowseAbandonment extends Template
      *
      * @return string
      */
-    private function getBrowseAbandonmentPageType() {
+    private function getBrowseAbandonmentPageType()
+    {
         $magentoPageTypeName = $this->getMagentoPageTypeName();
         return self::MAGENTO_PAGE_TYPE_NAME_TO_BROWSE_ABANDONMENT_PAGE_TYPE_NAME_MAP[$magentoPageTypeName];
     }
@@ -219,7 +223,8 @@ class BrowseAbandonment extends Template
      * @param string $browseAbandonmentPageType
      * @return int
      */
-    private function getIdByBrowseAbandonmentPageType($browseAbandonmentPageType) {
+    private function getIdByBrowseAbandonmentPageType($browseAbandonmentPageType)
+    {
         if (!in_array($browseAbandonmentPageType, self::BROWSE_ABANDONMENT_PAGE_TYPE_NAMES_ELIGIBLE_FOR_ID_ENRICHMENT)) {
             return null;
         }
@@ -250,7 +255,8 @@ class BrowseAbandonment extends Template
      *
      * @return int
      */
-    private function getCategoryId() {
+    private function getCategoryId()
+    {
         $category = $this->coreRegistry->registry('current_category');
         return $category->getId();
     }

--- a/CustomerData/CustomerBehaviour.php
+++ b/CustomerData/CustomerBehaviour.php
@@ -13,9 +13,13 @@ class CustomerBehaviour implements SectionSourceInterface
 {
     private CurrentCustomer $currentCustomer;
 
+    private Session $customerBehaviourSession;
+
     public function __construct(CurrentCustomer $currentCustomer, Session $session)
     {
         $this->currentCustomer = $currentCustomer;
+
+        $this->customerBehaviourSession = $session;
     }
 
     /**
@@ -25,6 +29,8 @@ class CustomerBehaviour implements SectionSourceInterface
     {
         $customer_id = $this->currentCustomer->getCustomerId();
 
-        return compact('customer_id');
+        $products_added_to_cart = $this->customerBehaviourSession->getData('products_added_to_cart', true);
+
+        return compact('customer_id', 'products_added_to_cart');
     }
 }

--- a/Model/Session.php
+++ b/Model/Session.php
@@ -6,8 +6,24 @@ use Magento\Framework\Session\SessionManager;
 
 /**
  * Message session model
+ *
+ * @method bool hasProductsAddedToCart() Magic method, true if "products_added_to_cart" is set
+ * @method mixed getProductsAddedToCart() Magic method, returns array of unclaimed "products_added_to_cart" events or null if none
  */
 class Session extends SessionManager
 {
+    /**
+     * Saves "product_added_to_cart" events in session
+     *
+     * @param array $productsInCart
+     * @return void
+     */
+    public function addProductsAddedToCart(array $productsInCart): void
+    {
+        $sessionData = $this->getProductsAddedToCart() ?: [];
 
+        array_push($sessionData, ...$productsInCart);
+
+        $this->setProductsAddedToCart($sessionData);
+    }
 }

--- a/Observer/SalesQuoteProductAddAfter.php
+++ b/Observer/SalesQuoteProductAddAfter.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Yotpo\SmsBump\Observer;
+
+use Magento\Catalog\Model\Product\Type as ProductType;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+use Magento\Quote\Model\Quote\Item as QuoteItem;
+use Yotpo\SmsBump\Model\Session;
+
+class SalesQuoteProductAddAfter implements ObserverInterface
+{
+    protected Session $session;
+
+
+    public function __construct(Session $session)
+    {
+        $this->session = $session;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function execute(Observer $observer)
+    {
+        /**
+         * @type QuoteItem[] $items
+         */
+        $items = $observer->getData('items');
+
+        $this->saveAddedToCartEvents($items);
+    }
+
+    /**
+     * Generate and store "product_added_to_cart" events in session
+     *
+     * @param QuoteItem[] $items
+     * @return void
+     */
+    protected function saveAddedToCartEvents(array $items = []): void
+    {
+        $ts = microtime(true);
+
+        $simpleProducts = array_filter(
+            $items,
+            fn($item) => $item->getProductType() === ProductType::TYPE_SIMPLE
+        );
+
+        $productsInCart = array_map(function ($item) use ($ts) {
+            $parent = $item->getParentItem();
+            $product = ($parent ?? $item)->getProduct();
+
+            return [
+                'id' => $product->getId(),
+                'variant_id' => $parent ? $item->getProduct()->getId() : null,
+                'page' => parse_url($product->getProductUrl(), PHP_URL_PATH),
+                'timestamp' => $ts,
+            ];
+        }, $simpleProducts);
+
+        if (!empty($productsInCart)) {
+            $this->session->addProductsAddedToCart($productsInCart);
+        }
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -102,4 +102,9 @@
             <argument name="customersReset" xsi:type="object">Yotpo\SmsBump\Model\Sync\Reset\Customers</argument>
         </arguments>
     </type>
+    <type name="Yotpo\SmsBump\Observer\SalesQuoteProductAddAfter">
+        <arguments>
+            <argument name="session" xsi:type="object">Yotpo\SmsBump\Model\Session</argument>
+        </arguments>
+    </type>
 </config>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -84,6 +84,8 @@
                 type="Yotpo\SmsBump\Model\Attribute\Data\Checkbox" />
     <preference for="Yotpo\SmsBump\Api\YotpoCustomersSyncRepositoryInterface"
                 type="Yotpo\SmsBump\Model\YotpoCustomersSyncRepository" />
+    <preference for="Yotpo\Core\Model\Sync\Customers\Processor"
+                type="Yotpo\SmsBump\Model\Sync\Customers\Processor" />
     <type name="Yotpo\Core\Console\Command\RetryYotpoSync">
         <arguments>
             <argument name="customersProcessor" xsi:type="object">Yotpo\SmsBump\Model\Sync\Customers\Processor</argument>

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -6,4 +6,7 @@
     <event name="customer_save_after">
         <observer name="yotpo_smsbump_customer_save_after" instance="Yotpo\SmsBump\Observer\CustomerSaveAfter"/>
     </event>
+    <event name="sales_quote_product_add_after">
+        <observer name="yotpo_smsbump_sales_quote_product_add_after" instance="Yotpo\SmsBump\Observer\SalesQuoteProductAddAfter"/>
+    </event>
 </config>

--- a/etc/frontend/di.xml
+++ b/etc/frontend/di.xml
@@ -7,6 +7,12 @@
             </argument>
         </arguments>
     </type>
+    <type name="Yotpo\SmsBump\CustomerData\CustomerBehaviour">
+        <arguments>
+            <argument name="currentCustomer" xsi:type="object">Magento\Customer\Helper\Session\CurrentCustomer</argument>
+            <argument name="session" xsi:type="object">Yotpo\SmsBump\Model\Session</argument>
+        </arguments>
+    </type>
     <type name="Magento\Checkout\Model\CompositeConfigProvider">
         <arguments>
             <argument name="configProviders" xsi:type="array">

--- a/etc/frontend/sections.xml
+++ b/etc/frontend/sections.xml
@@ -15,4 +15,7 @@
     <action name="customer/account/logout">
         <section name="yotposms-customer-behaviour"/>
     </action>
+    <action name="checkout/cart/add">
+        <section name="yotposms-customer-behaviour"/>
+    </action>
 </config>


### PR DESCRIPTION
## ⚠️ This PR is dependent on https://github.com/YotpoLtd/magento2-module-messaging/pull/128 ⚠️

This PR introduces tracking of add-to-cart events, storing it in session and feeding them to our tracking JS through customer-data layer introduced in https://github.com/YotpoLtd/magento2-module-messaging/pull/128.

Changes summary:

* Added an event observer `Yotpo\SmsBump\Observer\SalesQuoteProductAddAfter`. We are able to catch all "quotes" and store them in our custom session `Yotpo\SmsBump\Model\Session`.
* We have updated `Yotpo\SmsBump\CustomerData\CustomerBehaviour` to read from the session mentioned above and pass the events to the browser.
* Added `preference` for `Yotpo\Core\Model\Sync\Customers\Processor` in `di.xml` 
* Some cleanups and formatting for consistency.

Depends on: https://github.com/YotpoLtd/magento2-module-messaging/pull/128 and https://github.com/YotpoLtd/web-tracker/pull/19