### PR TITLE
OCT-FIX fix(smsMarketingBase):fixed not getting registered customer email in checkout checkbox

### DIFF
--- a/view/frontend/web/js/view/smsMarketingBase.js
+++ b/view/frontend/web/js/view/smsMarketingBase.js
@@ -59,6 +59,31 @@ define(
                 return '';
             },
 
+            getGuestCustomerEmail: function () {
+                if ($('#customer-email') && $('#customer-email').val()) {
+                    return $('#customer-email').val();
+                }
+
+                return null;
+            },
+
+            getRegisteredCustomerEmail: function () {
+                if (window.checkoutConfig.customerData.length === 0 || !window.checkoutConfig.customerData.email) {
+                    return null;
+                }
+
+                return window.checkoutConfig.customerData.email;
+            },
+
+            getCustomerEmail: function () {
+                var guestCustomerEmail = this.getGuestCustomerEmail()
+                if (guestCustomerEmail) {
+                    return guestCustomerEmail;
+                }
+
+                return this.getRegisteredCustomerEmail();
+            },
+
             updateCustomerAttribute: function () {
                 var linkUrl = url.build('yotpo_messaging/smsmarketing/savecustomerattribute');
                 var customDiv = $('#yotpo_accepts_sms_marketing');
@@ -68,10 +93,8 @@ define(
                 }
                 isCheckboxSelected = isCheckboxSelected ? 1 : 0;
                 var checkoutStep = this.getCheckoutStep();
-                var customerEmail = '';
-                if ($('#customer-email') && $('#customer-email').val()) {
-                    customerEmail = $('#customer-email').val();
-                }
+                var customerEmail = this.getCustomerEmail() || '';
+
                 fullScreenLoader.startLoader();
                 $.ajax({
                     url: linkUrl,


### PR DESCRIPTION
In the checkout page, we have a checkbox for getting customer's consent to get marketing materials.
The consent checkbox is sending an event to the Customers processor to subscribe the email address to marketing materials.
The logic behind the checkbox was dependent on the existence _#customer-email_ element.
However, whenever a registered customer is checking out, the element doesn't exist.