### PR TITLE
fix(login_action):remove strict result type

### DIFF
--- a/Plugin/Customer/Account/LoginPost.php
+++ b/Plugin/Customer/Account/LoginPost.php
@@ -62,7 +62,7 @@ class LoginPost
      * @throws NoSuchEntityException
      * @throws SessionException
      */
-    public function afterExecute(\Magento\Customer\Controller\Account\LoginPost $subject, Redirect $result)
+    public function afterExecute(\Magento\Customer\Controller\Account\LoginPost $subject, $result)
     {
         if (!$this->session->getCustomerId()) {
             return $result;

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "yotpo/module-yotpo-messaging",
     "description": "Yotpo Sms extension for Magento2",
-    "version": "4.3.0",
+    "version": "4.3.1",
     "license": [
         "OSL-3.0",
         "AFL-3.0"

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Yotpo_SmsBump" setup_version="4.3.0">
+    <module name="Yotpo_SmsBump" setup_version="4.3.1">
         <sequence>
             <Yotpo_Core/>
         </sequence>


### PR DESCRIPTION
https://yotpoent.atlassian.net/browse/KAT-1297

The client has experienced unwanted behaviour when they add an item to their wish list, without being logged in. Upon clicking on the "Add to wish list" button, they are prompted to add their credentials and when hitting the login button, an error appears. 

More technically, this issue is popping up because we want to execute an action immediately after the user has logged in. The method for this has the following signature:
`function afterExecute(\Magento\Customer\Controller\Account\LoginPost $subject, \Magento\Framework\Controller\Result\Redirect $result)`

However, in the case of adding an item to the wish list, the second argument is called with a type `\Magento\Framework\Controller\Result\Forward`, since on top of loggin the user in, we are redirecting them to their wish list, which is handled by another app controller - a forward opperation. 

Since we are not modifying that argument, I have decided not the enforce a strict type here (most examples I saw were exactly like this one) and this fixes the issue