### PR TITLE
fix(php):parameter update in favor of PHP 8.4 support [ ORB-3609 ]

### DIFF
--- a/Model/Config.php
+++ b/Model/Config.php
@@ -167,7 +167,7 @@ class Config extends CoreConfig
      * @throws LocalizedException
      * @throws NoSuchEntityException
      */
-    public function isCustomerSyncActive(int $scopeId = null, $scope = ScopeInterface::SCOPE_STORE)
+    public function isCustomerSyncActive($scopeId = null, $scope = ScopeInterface::SCOPE_STORE)
     {
         return $this->isEnabled($scopeId, $scope) && $this->getConfig('customers_sync_active', $scopeId, $scope);
     }


### PR DESCRIPTION
Since PHP 8.4, if you declare a function parameter with a specific non-nullable type, you can't assign null to it as a default value.
PHP 7.?? adds support for declaring optional parameters, but this module should also work for earlier PHP versions (5.6.0) 🙃, so I removed the type declarations of these parameters all together.