### PR TITLE
Fix PHP8.4 compatibility for nullable parameters

### DIFF
--- a/Plugin/Quote/Model/Quote.php
+++ b/Plugin/Quote/Model/Quote.php
@@ -18,7 +18,7 @@ class Quote extends AbstractCheckoutTrigger
      * @param AddressInterface $address
      * @return QuoteModel
      */
-    public function afterSetBillingAddress(QuoteModel $quote, $result, AddressInterface $address = null)
+    public function afterSetBillingAddress(QuoteModel $quote, $result, ?AddressInterface $address = null)
     {
         $this->checkoutSync($quote);
         if (!$this->registry->registry('yotpo_smsbump_quote_set_billing_address_plugin')){
@@ -35,7 +35,7 @@ class Quote extends AbstractCheckoutTrigger
      * @param AddressInterface $address
      * @return QuoteModel
      */
-    public function afterSetShippingAddress(QuoteModel $quote, $result, AddressInterface $address = null)
+    public function afterSetShippingAddress(QuoteModel $quote, $result, ?AddressInterface $address = null)
     {
         $this->checkoutSync($quote);
         if (!$this->registry->registry('yotpo_smsbump_quote_set_shipping_address_plugin')){


### PR DESCRIPTION
Same as #147 for another file

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Signature-only change to allow `null` address parameters; no business logic or data flow changes.
> 
> **Overview**
> Updates the `Quote` plugin method signatures to use nullable type hints (`?AddressInterface $address = null`) for `afterSetBillingAddress` and `afterSetShippingAddress`.
> 
> This is a PHP 8.4 compatibility fix that aligns the declared parameter types with the existing `null` default without changing the checkout sync behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a0aaf58dfb73534898d703bfeb79d604322be96f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->