### PR TITLE
Fix `core` version incompatability between yotpo on-site widgets

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "yotpo/module-yotpo-messaging",
     "description": "Yotpo Sms extension for Magento2",
-    "version": "4.3.5",
+    "version": "4.3.6",
     "license": [
         "OSL-3.0",
         "AFL-3.0"
@@ -9,7 +9,7 @@
     "require": {
         "php": "~5.6.0|^7.0|^8.0",
         "magento/framework": ">=102.0.0",
-        "yotpo/module-yotpo-core": "4.3.4"
+        "yotpo/module-yotpo-core": "4.3.7"
     },
     "type": "magento2-module",
     "autoload": {


### PR DESCRIPTION
Bumping the version of `core` due to issue with `composer` which cannot support two installed versions of the `core` module. This results as a broken state for a client.